### PR TITLE
user update with password, when changing password

### DIFF
--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -6,11 +6,52 @@ module V1
 
     load_and_authorize_resource class: 'User'
 
+    def update
+      # this is temporary thing allow transition for observation tool
+      if context[:app] == 'observations-tool' && !update_params[:current_password]
+        super
+      else
+        user = User.find(context[:current_user])
+        if user.send(update_action, update_params)
+          render json: JSONAPI::ResourceSerializer.new(
+            UserResource
+          ).serialize_to_hash(UserResource.new(user, context))
+        else
+          render json: ErrorSerializer.serialize(user.errors, 422), status: :unprocessable_entity
+        end
+      end
+    end
+
     def current
       user = User.find(context[:current_user])
       include_resources = %w[user_permission observer operator country observer.country]
-      render json: JSONAPI::ResourceSerializer.new(UserResource,
-                                                   include: include_resources).serialize_to_hash(UserResource.new(user, context))
+      render json: JSONAPI::ResourceSerializer.new(
+        UserResource,
+        include: include_resources
+      ).serialize_to_hash(UserResource.new(user, context))
+    end
+
+    private
+
+    def update_action
+      return "update_with_password" if update_params[:password]
+
+      "update"
+    end
+
+    def update_params
+      params
+        .require(:data)
+        .require(:attributes)
+        .permit(
+          :password,
+          :password_confirmation,
+          :current_password,
+          :name,
+          :nickname,
+          :email,
+          :locale,
+        )
     end
   end
 end

--- a/app/resources/v1/user_resource.rb
+++ b/app/resources/v1/user_resource.rb
@@ -14,7 +14,7 @@ module V1
     has_one :operator
 
     def self.fields
-      super - [:password, :password_confirmation]
+      super - [:password, :password_confirmation, :current_password]
     end
 
     filters :is_active, :email, :name, :nickname, :institution

--- a/app/resources/v1/user_resource.rb
+++ b/app/resources/v1/user_resource.rb
@@ -14,7 +14,7 @@ module V1
     has_one :operator
 
     def self.fields
-      super - [:password, :password_confirmation, :current_password]
+      super - [:password, :password_confirmation]
     end
 
     filters :is_active, :email, :name, :nickname, :institution

--- a/app/resources/v1/user_resource.rb
+++ b/app/resources/v1/user_resource.rb
@@ -8,11 +8,10 @@ module V1
                :permissions_request, :permissions_accepted, :password, :password_confirmation
 
     has_one :country
-    has_one    :user_permission, foreign_key_on: :related
-    has_many   :comments
+    has_one :user_permission, foreign_key_on: :related
+    has_many :comments
     has_one :observer
     has_one :operator
-
 
     def self.fields
       super - [:password, :password_confirmation]

--- a/spec/integration/v1/users_spec.rb
+++ b/spec/integration/v1/users_spec.rb
@@ -87,6 +87,35 @@ module V1
           expect(status).to eq(401)
           expect(user.reload.ngo?).to eq(false)
         end
+
+        describe 'Current Password validation' do
+          it 'requires current password when changing password' do
+            patch("/users/#{operator_user.id}",
+                  params: jsonapi_params('users', operator_user.id, { password: 'new_password' }),
+                  headers: operator_user_headers)
+
+            expect(status).to eq(422)
+            expect(parsed_body[:errors].first[:detail]).to eq("current-password - can't be blank")
+          end
+
+          it 'requires current password when changing email' do
+            patch("/users/#{operator_user.id}",
+                  params: jsonapi_params('users', operator_user.id, { email: 'newemail@example.com' }),
+                  headers: operator_user_headers)
+
+            expect(status).to eq(422)
+            expect(parsed_body[:errors].first[:detail]).to eq("current-password - can't be blank")
+          end
+
+          it 'does not require current password when changing password in observation tool' do
+            patch("/users/#{operator_user.id}?app=observations-tool",
+                  params: jsonapi_params('users', operator_user.id, { password: 'new_password' }),
+                  headers: operator_user_headers)
+
+            expect(status).to eq(200)
+            expect(operator_user.reload.valid_password?('new_password')).to eq(true)
+          end
+        end
       end
     end
   end

--- a/spec/integration/v1/users_spec.rb
+++ b/spec/integration/v1/users_spec.rb
@@ -28,17 +28,18 @@ module V1
       edit: {
         success_roles: %i[admin],
         failure_roles: %i[user],
-        excluded_params: %i[password password-confirmation permissions-request],
+        excluded_params: %i[password password-confirmation permissions-request current-password],
         valid_params: {
           email: 'test@gmail.com',
           nickname: 'sebanew',
           password: 'password',
           'password-confirmation': 'password',
+          'current-password': 'password',
           name: 'Test user new',
           'permissions-request': 'government'
         },
         invalid_params: { name: '', email: 'test@gmail.com', password: 'password', 'permissions-request': 'government' },
-        error_attributes: [422, 100, { 'name': ["can't be blank"] }]
+        error_attributes: [422, 100, { 'name': ["can't be blank"], 'current-password': ["can't be blank"] }]
       },
       delete: {
         success_roles: %i[admin],

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -81,6 +81,14 @@ module IntegrationHelper
     @user_headers ||= authorize_headers(user.id)
   end
 
+  def operator_user
+    @operator_user ||= create(:operator_user)
+  end
+
+  def operator_user_headers
+    @operator_user_headers ||= authorize_headers(operator_user.id)
+  end
+
   def authorize_headers(id, jsonapi: true)
     headers = {
       'Authorization' => "Bearer #{generate_token(id)}",


### PR DESCRIPTION
When changing email or password, the current password should be mandatory.

OTP portal does not have profile update yet, but observation tool does, so to not break profile update there I will temporarily allow password change without current password unless it is provided as a parameter. Later after changing observation tool that should be removed.