### PR TITLE
Remove nickname presence validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,13 +61,14 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :user_permission
 
-  validates :nickname,    presence: true, uniqueness: { case_sensitive: false }
+  validates :nickname, uniqueness: { case_sensitive: false, allow_blank: true }
   validates_uniqueness_of :email
   validates_format_of     :email, without: TEMP_EMAIL_REGEX, on: :update
   validates :name,        presence: true
   validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s), allow_blank: true }
   validates_format_of :nickname, with: /\A[a-z0-9_\.][-a-z0-9]{1,19}\Z/i,
-                                 multiline: true
+                                 multiline: true,
+                                 allow_blank: true
   validates :nickname, exclusion: { in: PROTECTED_NICKNAMES }
   validates :password, confirmation: true,
                        length: { within: 8..20 },

--- a/spec/integration/v1/user_registration_spec.rb
+++ b/spec/integration/v1/user_registration_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 module V1
   describe 'Register users', type: :request do
-    let(:error) { { errors: [{ status: 422, title: "nickname can't be blank" },
-                              { status: 422, title: "nickname is invalid"},
+    let(:error) { { errors: [
                               { status: 422, title: "name can't be blank"},
                               { status: 422, title: "password_confirmation can't be blank" }]}}
 
@@ -19,7 +18,6 @@ module V1
         password: 'password',
         password_confirmation: 'password',
         permissions_request: 'government',
-        nickname: 'sebanew',
         name: 'Test user new'
       }
     end

--- a/spec/integration/v1/users_spec.rb
+++ b/spec/integration/v1/users_spec.rb
@@ -20,7 +20,6 @@ module V1
         },
         invalid_params: { email: 'test@gmail.com', password: 'password', 'permissions-request': 'government' },
         error_attributes: [422, 100, {
-          nickname: ["can't be blank", 'is invalid'],
           name: ["can't be blank"],
           'password-confirmation': ["can't be blank"],
         }]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe User, type: :model do
   end
 
   describe 'Validations' do
-    it { is_expected.to validate_presence_of(:nickname) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:password_confirmation) }
 


### PR DESCRIPTION
The first step to remove nickname is to make that field not required and we will remove it from both frontend applications. Then it can be removed completely from database.