### PR TITLE
change to file_store in development mode, because of issues with memo…

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :file_store, "#{Rails.root}/tmp/cache/"
     config.public_file_server.headers = {
       'Cache-Control' => 'public, max-age=172800'
     }


### PR DESCRIPTION
Memory store was causing frontend otp portal to have circular references on observations page, because after visiting observations and then transparency ranking, the response of observations request changed somehow to include those references. Changing to file store as it is on staging or production.