### PR TITLE
Fix filter by observer for observation reports - eliminate duplicates

### DIFF
--- a/app/resources/v1/observation_report_resource.rb
+++ b/app/resources/v1/observation_report_resource.rb
@@ -17,7 +17,7 @@ module V1
     end
 
     filter :observer_id, apply: ->(records, value, _options) {
-      records.joins(:observers).where('observers.id = ?', value[0].to_i)
+      records.joins(:observers).where('observers.id = ?', value[0].to_i).distinct
     }
 
     # TODO: Reactivate rubocop and fix this


### PR DESCRIPTION
Observation tool is showing weird results in paginated table with observation reports. 
![nice-tables](https://user-images.githubusercontent.com/1286444/171634795-74db8e7a-654b-4f6a-87c0-45ee72c9ac3f.gif)
.
This PR should fix it.