### PR TITLE
Fix flaky specs

### DIFF
--- a/spec/integration/shared_examples/jsonapi_resources/filter.rb
+++ b/spec/integration/shared_examples/jsonapi_resources/filter.rb
@@ -12,6 +12,10 @@ RSpec.shared_examples 'jsonapi-resources__filter' do |options|
       end
     end
 
+    after(:context) do
+      @model_class.destroy_all
+    end
+
     (options[:success_roles] || [:webuser]).each do |role|
       describe "For user with #{role} role" do
         let(:headers) { respond_to?("#{role}_headers") ? send("#{role}_headers") : authorize_headers(create(role).id) }

--- a/spec/integration/shared_examples/jsonapi_resources/pagination.rb
+++ b/spec/integration/shared_examples/jsonapi_resources/pagination.rb
@@ -7,6 +7,10 @@ RSpec.shared_examples 'jsonapi-resources__pagination' do |options|
       @collection = create_list(@singular.to_sym, 6, options[:attributes] || {})
     end
 
+    after(:context) do
+      @model_class.destroy_all
+    end
+
     (options[:success_roles] || [:webuser]).each do |role|
       describe "For user with #{role} role" do
         let(:headers) { respond_to?("#{role}_headers") ? send("#{role}_headers") : authorize_headers(create(role).id) }

--- a/spec/integration/shared_examples/jsonapi_resources/sort.rb
+++ b/spec/integration/shared_examples/jsonapi_resources/sort.rb
@@ -13,6 +13,10 @@ RSpec.shared_examples 'jsonapi-resources__sort' do |options|
       end
     end
 
+    after(:context) do
+      @model_class.destroy_all
+    end
+
     (options[:success_roles] || [:webuser]).each do |role|
       describe "For user with #{role} role" do
         let(:headers) { respond_to?("#{role}_headers") ? send("#{role}_headers") : authorize_headers(create(role).id) }


### PR DESCRIPTION
Using `before(:context)` must be done with caution. Whatever is created in before(:context) should be removed in after(:context).

This should fix specs flakiness.