### PR TITLE
Add operator_id parameter to fmu tiles

### DIFF
--- a/app/admin/fmu.rb
+++ b/app/admin/fmu.rb
@@ -70,6 +70,28 @@ ActiveAdmin.register Fmu do
     column :certification_ls
   end
 
+  show do
+    attributes_table do
+      row :id
+      row :name
+      row :forest_type
+      row :country
+      row :operator
+      row :certification_fsc
+      row :certification_pefc
+      row :certification_olb
+      row :certification_pafc
+      row :certification_fsc_cw
+      row :certification_tlv
+      row :certification_ls
+      row(:geojson) { |fmu| fmu.geojson.to_json }
+      row :properties
+      row :created_at
+      row :updated_at
+      row :deleted_at
+    end
+  end
+
   index do
     column :id, sortable: true
     column :name, sortable: 'fmu_translations.name'

--- a/app/controllers/v1/fmus_controller.rb
+++ b/app/controllers/v1/fmus_controller.rb
@@ -18,7 +18,7 @@ module V1
     end
 
     def tiles
-      tile = Fmu.vector_tiles params[:z], params[:x], params[:y]
+      tile = Fmu.vector_tiles params[:z], params[:x], params[:y], params[:operator_id]
       send_data tile
     end
 
@@ -30,10 +30,9 @@ module V1
 
     def build_json(fmus)
       {
-          "type": "FeatureCollection",
-          "features": fmus.map(&:geojson)
+        "type": "FeatureCollection",
+        "features": fmus.map(&:geojson)
       }
     end
-
   end
 end

--- a/app/models/fmu.rb
+++ b/app/models/fmu.rb
@@ -102,20 +102,28 @@ class Fmu < ApplicationRecord
     end
 
     # Returns a vector tile for the X,Y,Z provided
-    def vector_tiles(param_z, param_x, param_y)
+    def vector_tiles(param_z, param_x, param_y, operator_id)
       begin
         x, y, z = Integer(param_x), Integer(param_y), Integer(param_z)
       rescue ArgumentError, TypeError
         return nil
       end
 
-      query =
-          <<~SQL
-            SELECT ST_ASMVT(tile.*, 'layer0', 4096, 'mvtgeometry', 'id') as tile
-             FROM (SELECT id, properties, ST_AsMVTGeom(the_geom_webmercator, ST_TileEnvelope(#{z},#{x},#{y}), 4096, 256, true) AS mvtgeometry
-                                      FROM (select *, st_transform(geometry, 3857) as the_geom_webmercator from fmus WHERE deleted_at IS NULL) as data
-                                    WHERE ST_AsMVTGeom(the_geom_webmercator, ST_TileEnvelope(#{z},#{x},#{y}),4096,0,true) IS NOT NULL) AS tile;
-          SQL
+      operator_condition = operator_id.present? ? sanitize_sql(["AND operator_id=?", operator_id]) : ""
+
+      query = <<~SQL
+        SELECT ST_ASMVT(tile.*, 'layer0', 4096, 'mvtgeometry', 'id') as tile
+          FROM (
+            SELECT id, properties, ST_AsMVTGeom(the_geom_webmercator, ST_TileEnvelope(#{z},#{x},#{y}), 4096, 256, true) AS mvtgeometry
+            FROM (
+              SELECT fmus.*, st_transform(geometry, 3857) as the_geom_webmercator
+              FROM fmus
+                LEFT JOIN fmu_operators fo on fo.fmu_id = fmus.id
+              WHERE fmus.deleted_at IS NULL #{operator_condition}
+            ) as data
+            WHERE ST_AsMVTGeom(the_geom_webmercator, ST_TileEnvelope(#{z},#{x},#{y}),4096,0,true) IS NOT NULL
+          ) AS tile;
+      SQL
 
       tile = ActiveRecord::Base.connection.execute query
       ActiveRecord::Base.connection.unescape_bytea tile.getvalue(0, 0)

--- a/doc/api/open_api.json
+++ b/doc/api/open_api.json
@@ -15,9 +15,9 @@
     },
     "version": "v1"
   },
-  "host": "opentimberportal.org/api",
+  "host": "",
   "schemes": [
-    "https"
+    "http"
   ],
   "consumes": [
     "application/vnd.api+json"
@@ -26,6 +26,412 @@
     "application/vnd.api+json"
   ],
   "paths": {
+    "fmus?format=geojson": {
+      "get": {
+        "tags": [
+          "Fmus"
+        ],
+        "summary": "Lists all the fmus in geojson format",
+        "description": "All the fmus retrieved in the geojson format",
+        "consumes": [
+          "application/vnd.api+json"
+        ],
+        "produces": [
+          "application/vnd.api+json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Listing fmus in geojson",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            },
+            "headers": {},
+            "examples": {}
+          }
+        },
+        "deprecated": false,
+        "security": [
+          {
+            "OTP-API-KEY": []
+          }
+        ]
+      }
+    },
+    "/fmus": {
+      "get": {
+        "tags": [
+          "Fmus"
+        ],
+        "summary": "Lists all the fmus",
+        "description": "It fetches all the fmus.\nIf the parameter format=geojson is provided, the fmus will come in the geojson format and all the other parameters will be ignored.\nIf not, then the request is processed as a typical JSON API request.",
+        "consumes": [
+          "application/vnd.api+json"
+        ],
+        "produces": [
+          "application/vnd.api+json"
+        ],
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "description": "related relationships to include: country, operator",
+            "required": false,
+            "type": "string",
+            "example": [
+              "country",
+              "operator"
+            ]
+          },
+          {
+            "name": "filter[id]",
+            "in": "query",
+            "description": "filter by id",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter[country]",
+            "in": "query",
+            "description": "filter by country",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter[free]",
+            "in": "query",
+            "description": "filter by free",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter[certification]",
+            "in": "query",
+            "description": "filter by certification",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter[operator]",
+            "in": "query",
+            "description": "filter by operator",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "fields[fmus]",
+            "in": "query",
+            "description": "a comma separated list of fmu attributes you wish to limit (must be dasherized)",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "page[limit]",
+            "in": "query",
+            "description": "max number of items",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "page[offset]",
+            "in": "query",
+            "description": "page offset",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "page[number]",
+            "in": "query",
+            "description": "page number",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "page[size]",
+            "in": "query",
+            "description": "the number of resources to be returned per page",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort order",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Listing fmus",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            },
+            "headers": {},
+            "examples": {}
+          }
+        },
+        "deprecated": false,
+        "security": [
+          {
+            "OTP-API-KEY": []
+          }
+        ]
+      }
+    },
+    "/fmus/tiles/{x}/{y}/{z}": {
+      "get": {
+        "tags": [
+          "Fmus"
+        ],
+        "summary": "Fetches the vector tiles",
+        "description": "It gets the vector tiles for the provided coordinates and Z index",
+        "consumes": [
+          "application/vnd.api+json"
+        ],
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "name": "x",
+            "in": "path",
+            "description": "X coordinate",
+            "required": true,
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          },
+          {
+            "name": "y",
+            "in": "path",
+            "description": "Y coordinate",
+            "required": true,
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          },
+          {
+            "name": "z",
+            "in": "path",
+            "description": "Z index",
+            "required": true,
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          },
+          {
+            "name": "operator_id",
+            "in": "query",
+            "description": "Operator Id",
+            "required": false,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Getting highest level tiles",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            },
+            "headers": {},
+            "examples": {}
+          }
+        },
+        "deprecated": false,
+        "security": [
+          {
+            "OTP-API-KEY": []
+          }
+        ]
+      }
+    },
+    "/countries/{id}": {
+      "get": {
+        "tags": [
+          "Countries"
+        ],
+        "summary": "Fetches a country by id",
+        "description": "It fetches a country by id and implements the JSON API standard",
+        "consumes": [
+          "application/vnd.api+json"
+        ],
+        "produces": [
+          "application/vnd.api+json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "related relationships to include: fmus, operator",
+            "required": false,
+            "type": "string",
+            "example": [
+              "fmus",
+              "operator"
+            ]
+          },
+          {
+            "name": "fields[countries]",
+            "in": "query",
+            "description": "a comma separated list of country attributes you wish to limit (must be dasherized)",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Country not found",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            },
+            "headers": {},
+            "examples": {}
+          },
+          "200": {
+            "description": "Get one country",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            },
+            "headers": {},
+            "examples": {}
+          }
+        },
+        "deprecated": false,
+        "security": [
+          {
+            "OTP-API-KEY": []
+          }
+        ]
+      }
+    },
+    "/countries": {
+      "get": {
+        "tags": [
+          "Countries"
+        ],
+        "summary": "Fetches all the countries",
+        "description": "It fetches all the countries and it implements JSON API.\nIf the parameter \"is-active\" is absent, it will by default send only the active countries",
+        "consumes": [
+          "application/vnd.api+json"
+        ],
+        "produces": [
+          "application/vnd.api+json"
+        ],
+        "parameters": [
+          {
+            "name": "is-active",
+            "in": "query",
+            "description": "true",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "related relationships to include: fmus, operator",
+            "required": false,
+            "type": "string",
+            "example": [
+              "fmus",
+              "operator"
+            ]
+          },
+          {
+            "name": "filter[id]",
+            "in": "query",
+            "description": "filter by id",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter[iso]",
+            "in": "query",
+            "description": "filter by iso",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter[is_active]",
+            "in": "query",
+            "description": "filter by is_active",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "fields[countries]",
+            "in": "query",
+            "description": "a comma separated list of country attributes you wish to limit (must be dasherized)",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "page[limit]",
+            "in": "query",
+            "description": "max number of items",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "page[offset]",
+            "in": "query",
+            "description": "page offset",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "page[number]",
+            "in": "query",
+            "description": "page number",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "page[size]",
+            "in": "query",
+            "description": "the number of resources to be returned per page",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort order",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Listing countries",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            },
+            "headers": {},
+            "examples": {}
+          }
+        },
+        "deprecated": false,
+        "security": [
+          {
+            "OTP-API-KEY": []
+          }
+        ]
+      }
+    },
     "/operators/{id}": {
       "get": {
         "tags": [
@@ -240,405 +646,6 @@
           }
         ]
       }
-    },
-    "fmus?format=geojson": {
-      "get": {
-        "tags": [
-          "Fmus"
-        ],
-        "summary": "Lists all the fmus in geojson format",
-        "description": "All the fmus retrieved in the geojson format",
-        "consumes": [
-          "application/vnd.api+json"
-        ],
-        "produces": [
-          "application/vnd.api+json"
-        ],
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Listing fmus in geojson",
-            "schema": {
-              "type": "object",
-              "properties": {}
-            },
-            "headers": {},
-            "examples": {}
-          }
-        },
-        "deprecated": false,
-        "security": [
-          {
-            "OTP-API-KEY": []
-          }
-        ]
-      }
-    },
-    "/fmus": {
-      "get": {
-        "tags": [
-          "Fmus"
-        ],
-        "summary": "Lists all the fmus",
-        "description": "It fetches all the fmus.\nIf the parameter format=geojson is provided, the fmus will come in the geojson format and all the other parameters will be ignored.\nIf not, then the request is processed as a typical JSON API request.",
-        "consumes": [
-          "application/vnd.api+json"
-        ],
-        "produces": [
-          "application/vnd.api+json"
-        ],
-        "parameters": [
-          {
-            "name": "include",
-            "in": "query",
-            "description": "related relationships to include: country, operator",
-            "required": false,
-            "type": "string",
-            "example": [
-              "country",
-              "operator"
-            ]
-          },
-          {
-            "name": "filter[id]",
-            "in": "query",
-            "description": "filter by id",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "filter[country]",
-            "in": "query",
-            "description": "filter by country",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "filter[free]",
-            "in": "query",
-            "description": "filter by free",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "filter[certification]",
-            "in": "query",
-            "description": "filter by certification",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "filter[operator]",
-            "in": "query",
-            "description": "filter by operator",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "fields[fmus]",
-            "in": "query",
-            "description": "a comma separated list of fmu attributes you wish to limit (must be dasherized)",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "page[limit]",
-            "in": "query",
-            "description": "max number of items",
-            "required": false,
-            "type": "integer"
-          },
-          {
-            "name": "page[offset]",
-            "in": "query",
-            "description": "page offset",
-            "required": false,
-            "type": "integer"
-          },
-          {
-            "name": "page[number]",
-            "in": "query",
-            "description": "page number",
-            "required": false,
-            "type": "integer"
-          },
-          {
-            "name": "page[size]",
-            "in": "query",
-            "description": "the number of resources to be returned per page",
-            "required": false,
-            "type": "integer"
-          },
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort order",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Listing fmus",
-            "schema": {
-              "type": "object",
-              "properties": {}
-            },
-            "headers": {},
-            "examples": {}
-          }
-        },
-        "deprecated": false,
-        "security": [
-          {
-            "OTP-API-KEY": []
-          }
-        ]
-      }
-    },
-    "/fmus/tiles/{x}/{y}/{z}": {
-      "get": {
-        "tags": [
-          "Fmus"
-        ],
-        "summary": "Fetches the vector tiles",
-        "description": "It gets the vector tiles for the provided coordinates and Z index",
-        "consumes": [
-          "application/vnd.api+json"
-        ],
-        "produces": [
-          "application/octet-stream"
-        ],
-        "parameters": [
-          {
-            "name": "x",
-            "in": "path",
-            "description": "X coordinate",
-            "required": true,
-            "type": "integer",
-            "default": 1,
-            "minimum": 1
-          },
-          {
-            "name": "y",
-            "in": "path",
-            "description": "Y coordinate",
-            "required": true,
-            "type": "integer",
-            "default": 1,
-            "minimum": 1
-          },
-          {
-            "name": "z",
-            "in": "path",
-            "description": "Z index",
-            "required": true,
-            "type": "integer",
-            "default": 1,
-            "minimum": 1
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Getting highest level tiles",
-            "schema": {
-              "type": "object",
-              "properties": {}
-            },
-            "headers": {},
-            "examples": {}
-          }
-        },
-        "deprecated": false,
-        "security": [
-          {
-            "OTP-API-KEY": []
-          }
-        ]
-      }
-    },
-    "/countries": {
-      "get": {
-        "tags": [
-          "Countries"
-        ],
-        "summary": "Fetches all the countries",
-        "description": "It fetches all the countries and it implements JSON API.\nIf the parameter \"is-active\" is absent, it will by default send only the active countries",
-        "consumes": [
-          "application/vnd.api+json"
-        ],
-        "produces": [
-          "application/vnd.api+json"
-        ],
-        "parameters": [
-          {
-            "name": "is-active",
-            "in": "query",
-            "description": "true",
-            "required": false,
-            "type": "boolean"
-          },
-          {
-            "name": "include",
-            "in": "query",
-            "description": "related relationships to include: fmus, operator",
-            "required": false,
-            "type": "string",
-            "example": [
-              "fmus",
-              "operator"
-            ]
-          },
-          {
-            "name": "filter[id]",
-            "in": "query",
-            "description": "filter by id",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "filter[iso]",
-            "in": "query",
-            "description": "filter by iso",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "filter[is_active]",
-            "in": "query",
-            "description": "filter by is_active",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "fields[countries]",
-            "in": "query",
-            "description": "a comma separated list of country attributes you wish to limit (must be dasherized)",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "page[limit]",
-            "in": "query",
-            "description": "max number of items",
-            "required": false,
-            "type": "integer"
-          },
-          {
-            "name": "page[offset]",
-            "in": "query",
-            "description": "page offset",
-            "required": false,
-            "type": "integer"
-          },
-          {
-            "name": "page[number]",
-            "in": "query",
-            "description": "page number",
-            "required": false,
-            "type": "integer"
-          },
-          {
-            "name": "page[size]",
-            "in": "query",
-            "description": "the number of resources to be returned per page",
-            "required": false,
-            "type": "integer"
-          },
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort order",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Listing countries",
-            "schema": {
-              "type": "object",
-              "properties": {}
-            },
-            "headers": {},
-            "examples": {}
-          }
-        },
-        "deprecated": false,
-        "security": [
-          {
-            "OTP-API-KEY": []
-          }
-        ]
-      }
-    },
-    "/countries/{id}": {
-      "get": {
-        "tags": [
-          "Countries"
-        ],
-        "summary": "Fetches a country by id",
-        "description": "It fetches a country by id and implements the JSON API standard",
-        "consumes": [
-          "application/vnd.api+json"
-        ],
-        "produces": [
-          "application/vnd.api+json"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "id",
-            "required": true,
-            "type": "integer"
-          },
-          {
-            "name": "include",
-            "in": "query",
-            "description": "related relationships to include: fmus, operator",
-            "required": false,
-            "type": "string",
-            "example": [
-              "fmus",
-              "operator"
-            ]
-          },
-          {
-            "name": "fields[countries]",
-            "in": "query",
-            "description": "a comma separated list of country attributes you wish to limit (must be dasherized)",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Country not found",
-            "schema": {
-              "type": "object",
-              "properties": {}
-            },
-            "headers": {},
-            "examples": {}
-          },
-          "200": {
-            "description": "Get one country",
-            "schema": {
-              "type": "object",
-              "properties": {}
-            },
-            "headers": {},
-            "examples": {}
-          }
-        },
-        "deprecated": false,
-        "security": [
-          {
-            "OTP-API-KEY": []
-          }
-        ]
-      }
     }
   },
   "securityDefinitions": {
@@ -650,16 +657,16 @@
   },
   "tags": [
     {
-      "name": "Operators",
-      "description": "Operators resource"
-    },
-    {
       "name": "Fmus",
       "description": "FMUs resource"
     },
     {
       "name": "Countries",
       "description": "Countries resource"
+    },
+    {
+      "name": "Operators",
+      "description": "Operators resource"
     }
   ]
 }

--- a/spec/acceptance/fmus_spec.rb
+++ b/spec/acceptance/fmus_spec.rb
@@ -58,6 +58,9 @@ If not, then the request is processed as a typical JSON API request.'
               type: :integer, with_example: true, default: 1, minimum: 1
     parameter :z, 'Z index', in: 'path',
               type: :integer, with_example: true, default: 1, minimum: 1
+    parameter :operator_id, 'Operator Id', in: 'query', type: :integer
+
+    let(:operator_id) { operator.id }
 
     context '200' do
       example_request 'Getting highest level tiles' do


### PR DESCRIPTION
Parameter `operator_id` would be great to just fetch FMU tiles that belongs to operator (for FMUs map). Otherwise we download all tiles, wasting server resources and there is a bug that I'm trying to reproduce that is showing shape from FMU that does not even belong to viewed operator.