### PR TITLE
Hot fix - remove distinct

### DIFF
--- a/app/resources/v1/observation_report_resource.rb
+++ b/app/resources/v1/observation_report_resource.rb
@@ -17,7 +17,7 @@ module V1
     end
 
     filter :observer_id, apply: ->(records, value, _options) {
-      records.joins(:observers).where('observers.id = ?', value[0].to_i).distinct
+      records.where(id: ObservationReportObserver.where(observer_id: value[0].to_i).pluck(:observation_report_id))
     }
 
     # TODO: Reactivate rubocop and fix this


### PR DESCRIPTION
That was causing problems like

```
PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
LINE 1: ...eted_at" IS NULL AND (observers.id = 16) ORDER BY "observati...
```