### PR TITLE
Add observations sidebar for producers

### DIFF
--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -147,7 +147,7 @@ ActiveAdmin.register Operator, as: 'Producer' do
   sidebar 'Observations', only: :show do
     attributes_table_for resource do
       div do
-        resource.all_observations.collect do |observation|
+        resource.all_observations.order(:id).collect do |observation|
           link_to(observation.id, admin_observation_path(observation.id))
         end.join(', ').html_safe
       end

--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -146,10 +146,10 @@ ActiveAdmin.register Operator, as: 'Producer' do
 
   sidebar 'Observations', only: :show do
     attributes_table_for resource do
-      ul do
+      div do
         resource.all_observations.collect do |observation|
-          li link_to(observation.id, admin_observation_path(observation.id))
-        end
+          link_to(observation.id, admin_observation_path(observation.id))
+        end.join(', ').html_safe
       end
     end
   end

--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -144,6 +144,16 @@ ActiveAdmin.register Operator, as: 'Producer' do
     end
   end
 
+  sidebar 'Observations', only: :show do
+    attributes_table_for resource do
+      ul do
+        resource.all_observations.collect do |observation|
+          li link_to(observation.id, admin_observation_path(observation.id))
+        end
+      end
+    end
+  end
+
   sidebar 'Sawmills', only: :show do
     attributes_table_for resource do
       ul do

--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -146,11 +146,13 @@ ActiveAdmin.register Operator, as: 'Producer' do
 
   sidebar 'Observations', only: :show do
     attributes_table_for resource do
+      # rubocop:disable Rails/OutputSafety
       div do
         resource.all_observations.order(:id).collect do |observation|
           link_to(observation.id, admin_observation_path(observation.id))
         end.join(', ').html_safe
       end
+      # rubocop:enable Rails/OutputSafety
     end
   end
 


### PR DESCRIPTION
Description from Pivotal Tracker

In back office, producer profiles do not display associated observations. We would like to add a box that would allow users to see the observation IDs when they view a profile.
Proposed action:
• Add a box on the left-hand side of producers’ profile that will display all of the observation IDs associated to that profile.
Expected result:
• When viewing the profile of a producer in the back office, OTP admins can see the list of observations that are associated to that profile.

https://www.pivotaltracker.com/story/show/181286859
