### PR TITLE
Feature/removing observation reports and evidences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ spec/.DS_Store
 /vendor/bundle
 /public/assets
 /public/uploads
+/private_uploads
 /public/system
 /coverage
 /db/files/.~*

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ spec/.DS_Store
 /vendor/bundle
 /public/assets
 /public/uploads
-/private_uploads
+/private
 /public/system
 /coverage
 /db/files/.~*

--- a/app/admin/observation_document.rb
+++ b/app/admin/observation_document.rb
@@ -9,9 +9,21 @@ ActiveAdmin.register ObservationDocument, as: 'Evidence' do
 
   menu false
 
-  actions :show, :index, :create
+  actions :all, except: [:new]
 
   config.order_clause
+  active_admin_paranoia
+
+  permit_params :name, :attachment
+
+  member_action :really_destroy, method: :delete do
+    if resource.deleted?
+      resource.really_destroy!
+      redirect_to :back, notice: 'Evidence removed!'
+    else
+      redirect_to :back, notice: 'Evidence must be moved to recycle bin first!'
+    end
+  end
 
   csv do
     column :id
@@ -36,7 +48,19 @@ ActiveAdmin.register ObservationDocument, as: 'Evidence' do
     column :created_at, sortable: true
     column :updated_at, sortable: :true
     column :deleted_at, sortable: true
-    actions
+
+    actions defaults: false do |evidence|
+      if evidence.deleted?
+        item 'Restore', restore_admin_evidence_path(evidence), method: :put
+        item 'Remove Completely', really_destroy_admin_evidence_path(evidence),
+             method: :delete, data: { confirm: 'Are you sure you want to remove the evidence completely? This action is not reversible.' }
+      else
+        item 'View', admin_evidence_path(evidence)
+        item 'Edit', edit_admin_evidence_path(evidence)
+        item 'Delete', admin_evidence_path(evidence),
+             method: :delete, data: { confirm: 'Are you sure you want to move evidence to the recycle bin?' }
+      end
+    end
   end
 
   filter :observation, as: :select,
@@ -49,6 +73,17 @@ ActiveAdmin.register ObservationDocument, as: 'Evidence' do
   filter :updated_at
   filter :deleted_at
 
+  form do |f|
+    f.semantic_errors *f.object.errors.keys
+    f.inputs 'Evidence Details' do
+      f.input :observation, collection: Observation.all.map { |o| [o.id, o.id] }, input_html: { disabled: true }
+      f.input :user, input_html: { disabled: true }
+      f.input :name
+      f.input :attachment, as: :file, hint: f.object&.attachment&.file&.filename
+
+      f.actions
+    end
+  end
 
   show do
     attributes_table do

--- a/app/admin/observation_report.rb
+++ b/app/admin/observation_report.rb
@@ -23,6 +23,15 @@ ActiveAdmin.register ObservationReport do
     end
   end
 
+  member_action :really_destroy, method: :delete do
+    if resource.deleted?
+      resource.really_destroy!
+      redirect_to :back, notice: 'Report removed!'
+    else
+      redirect_to :back, notice: 'Report must be moved to recycle bin first!'
+    end
+  end
+
   filter :title, as: :select
   filter :attachment, as: :select
   filter :user, as: :select, collection: User.order(:name)
@@ -93,14 +102,14 @@ ActiveAdmin.register ObservationReport do
 
     actions defaults: false do |report|
       if report.deleted?
-        link_to "Restore", restore_admin_observation_report_path(report), method: :put
+        item 'Restore', restore_admin_observation_report_path(report), method: :put
+        item 'Remove Completely', really_destroy_admin_observation_report_path(report),
+             method: :delete, data: { confirm: 'Are you sure you want to remove the report completely? This action is not reversible.' }
       else
-        item "View", admin_observation_report_path(report)
-        text_node "<br/>".html_safe
-        item "Edit", edit_admin_observation_report_path(report)
-        text_node "<br/>".html_safe
-        link_to 'Delete', admin_observation_report_path(report),
-                method: :delete, data: { confirm: ObservationReportDecorator.new(report).delete_confirmation_text }
+        item 'View', admin_observation_report_path(report)
+        item 'Edit', edit_admin_observation_report_path(report)
+        item 'Delete', admin_observation_report_path(report),
+             method: :delete, data: { confirm: ObservationReportDecorator.new(report).delete_confirmation_text }
       end
     end
   end

--- a/app/admin/observation_report.rb
+++ b/app/admin/observation_report.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register ObservationReport do
 
   menu false
 
-  actions :show, :index, :update, :edit, :create
+  actions :all, except: [:new]
 
   permit_params :user_id, :title, :publication_date, :attachment
 
@@ -30,6 +30,17 @@ ActiveAdmin.register ObservationReport do
                      collection: -> { Observer.with_translations(I18n.locale).order('observer_translations.name') }
   filter :observations, as: :select, collection: Observation.order(:id).pluck(:id)
   filter :publication_date
+
+  config.clear_action_items!
+
+  action_item only: [:show] do
+    link_to 'Edit Report', edit_admin_observation_report_path(observation_report)
+  end
+
+  action_item only: [:show], unless: -> { observation_report.deleted? } do
+    link_to 'Delete Report', admin_observation_report_path(observation_report),
+            method: :delete, data: { confirm: ObservationReportDecorator.new(observation_report).delete_confirmation_text }
+  end
 
   csv do
     column :id
@@ -54,7 +65,11 @@ ActiveAdmin.register ObservationReport do
   index do
     column :id
     column :title do |report|
-      link_to(report.title, admin_observation_report_path(report.id))
+      if report.deleted?
+        report.title
+      else
+        link_to(report.title, admin_observation_report_path(report.id))
+      end
     end
     column :publication_date
     attachment_column :attachment
@@ -76,7 +91,18 @@ ActiveAdmin.register ObservationReport do
     column :created_at
     column :updated_at
 
-    actions
+    actions defaults: false do |report|
+      if report.deleted?
+        link_to "Restore", restore_admin_observation_report_path(report), method: :put
+      else
+        item "View", admin_observation_report_path(report)
+        text_node "<br/>".html_safe
+        item "Edit", edit_admin_observation_report_path(report)
+        text_node "<br/>".html_safe
+        link_to 'Delete', admin_observation_report_path(report),
+                method: :delete, data: { confirm: ObservationReportDecorator.new(report).delete_confirmation_text }
+      end
+    end
   end
 
   form do |f|

--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -43,13 +43,7 @@ ActiveAdmin.register Operator, as: 'Producer' do
   end
 
   action_item only: [:show] do
-    confirmation_text =
-      if operator&.all_observations&.any?
-        "The operator has the observations with the ids: #{operator.all_observations.pluck(:id).join(', ')}.\nIf you want to keep them associated to the operator, please archive the operator instead."
-      else
-        'Are you sure you want to delete the producer?'
-      end
-    link_to 'Delete Producer', admin_producer_path(operator), method: :delete, data: { confirm: confirmation_text }
+    link_to 'Delete Producer', admin_producer_path(operator), method: :delete, data: { confirm: OperatorDecorator.new(operator).delete_confirmation_text }
   end
 
   action_item only: [:index] do
@@ -111,13 +105,7 @@ ActiveAdmin.register Operator, as: 'Producer' do
       text_node "<br/>".html_safe
       item "Edit", edit_admin_producer_path(operator)
       text_node "<br/>".html_safe
-      confirmation_text =
-          if operator&.all_observations&.any?
-            "The operator has the observations with the ids: #{operator.all_observations.pluck(:id).join(', ')}.\nIf you want to keep them associated to the operator, please archive the operator instead."
-          else
-            'Are you sure you want to delete the producer?'
-          end
-      link_to 'Delete', admin_producer_path(operator), method: :delete, data: { confirm: confirmation_text }
+      link_to 'Delete', admin_producer_path(operator), method: :delete, data: { confirm: OperatorDecorator.new(operator).delete_confirmation_text }
     end
   end
 

--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -102,10 +102,8 @@ ActiveAdmin.register Operator, as: 'Producer' do
 
     actions defaults: false do |operator|
       item "View", admin_producer_path(operator)
-      text_node "<br/>".html_safe
       item "Edit", edit_admin_producer_path(operator)
-      text_node "<br/>".html_safe
-      link_to 'Delete', admin_producer_path(operator), method: :delete, data: { confirm: OperatorDecorator.new(operator).delete_confirmation_text }
+      item 'Delete', admin_producer_path(operator), method: :delete, data: { confirm: OperatorDecorator.new(operator).delete_confirmation_text }
     end
   end
 

--- a/app/controllers/private_uploads_controller.rb
+++ b/app/controllers/private_uploads_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class PrivateUploadsController < ApplicationController
+  before_action :authenticate_user!
+
+  def download
+    filepath = "#{params[:rest]}.#{params[:format]}"
+    send_file_inside File.join(Rails.root, 'private_uploads'), filepath, disposition: :inline
+  end
+
+  private
+
+  def send_file_inside(allowed_path, filename, options = {})
+    path = File.expand_path(File.join(allowed_path, filename))
+    if path.match Regexp.new('^' + Regexp.escape(allowed_path))
+      send_file path, options
+    else
+      raise 'Disallowed file requested'
+    end
+  end
+end

--- a/app/controllers/private_uploads_controller.rb
+++ b/app/controllers/private_uploads_controller.rb
@@ -3,19 +3,39 @@
 class PrivateUploadsController < ApplicationController
   before_action :authenticate_user!
 
+  rescue_from ActionController::MissingFile, with: :raise_not_found_exception
+
   def download
     filepath = "#{params[:rest]}.#{params[:format]}"
-    send_file_inside File.join(Rails.root, 'private', 'uploads'), filepath, disposition: :inline
+    send_file_inside allowed_filepath, filepath, disposition: :inline
   end
 
   private
+
+  def authenticate_user!
+    if current_user.present?
+      super
+    else
+      raise_not_found_exception
+    end
+  end
+
+  def allowed_filepath
+    return File.join(Rails.root, 'tmp', 'private', 'uploads') if Rails.env.test?
+
+    File.join(Rails.root, 'private', 'uploads')
+  end
 
   def send_file_inside(allowed_path, filename, options = {})
     path = File.expand_path(File.join(allowed_path, filename))
     if path.match Regexp.new('^' + Regexp.escape(allowed_path))
       send_file path, options
     else
-      raise 'Disallowed file requested'
+      raise_not_found_exception
     end
+  end
+
+  def raise_not_found_exception
+    raise ActionController::RoutingError, 'Not Found'
   end
 end

--- a/app/controllers/private_uploads_controller.rb
+++ b/app/controllers/private_uploads_controller.rb
@@ -5,7 +5,7 @@ class PrivateUploadsController < ApplicationController
 
   def download
     filepath = "#{params[:rest]}.#{params[:format]}"
-    send_file_inside File.join(Rails.root, 'private_uploads'), filepath, disposition: :inline
+    send_file_inside File.join(Rails.root, 'private', 'uploads'), filepath, disposition: :inline
   end
 
   private

--- a/app/decorators/base_decorator.rb
+++ b/app/decorators/base_decorator.rb
@@ -9,6 +9,10 @@ class BaseDecorator < SimpleDelegator
     collection.map { |item| new(item, view_context) }
   end
 
+  def self.decorate(model, view_context = nil)
+    new(model, view_context)
+  end
+
   def initialize(model, view_context = nil)
     super(model)
     @model = model

--- a/app/decorators/observation_report_decorator.rb
+++ b/app/decorators/observation_report_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ObservationReportDecorator < BaseDecorator
+  def delete_confirmation_text
+    if model&.observations&.any?
+      "The report has the observations with the ids: #{model.observation_ids.join(', ')}. Are you sure you want to move it to recycle bin?"
+    else
+      'Are you sure you want to move this report to recycle bin?'
+    end
+  end
+end

--- a/app/decorators/operator_decorator.rb
+++ b/app/decorators/operator_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class OperatorDecorator < BaseDecorator
+  def delete_confirmation_text
+    if model&.all_observations&.any?
+      "The operator has the observations with the ids: #{model.all_observation_ids.join(', ')}.\nIf you want to keep them associated to the operator, please archive the operator instead."
+    else
+      'Are you sure you want to delete the producer?'
+    end
+  end
+end

--- a/app/models/concerns/moveable_attachment.rb
+++ b/app/models/concerns/moveable_attachment.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module MoveableAttachment
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    uploaders.each_key do |uploader|
+      define_method "move_#{uploader}_to_public_directory" do
+        return unless attachment
+
+        from = File.dirname(attachment.file.file.gsub('/public/', '/private/'))
+        to = File.dirname(from.gsub('/private/', '/public/'))
+        move_attachment(from: from, to: to)
+      end
+
+      define_method "move_#{uploader}_to_private_directory" do
+        return unless attachment
+
+        from = File.dirname(attachment.file.file.gsub('/private/', '/public/'))
+        to = File.dirname(from.gsub('/public/', '/private/'))
+        move_attachment(from: from, to: to)
+      end
+    end
+
+    def move_attachment(from:, to:)
+      FileUtils.makedirs(to)
+      FileUtils.mv(from, to, force: true)
+    end
+  end
+end

--- a/app/models/concerns/moveable_attachment.rb
+++ b/app/models/concerns/moveable_attachment.rb
@@ -26,7 +26,8 @@ module MoveableAttachment
 
     def move_attachment(from:, to:)
       FileUtils.makedirs(to)
-      system "mv -f #{from} #{to}"
+      system "rsync -a #{from} #{to}"
+      system "rm -rf #{from}"
     end
   end
 end

--- a/app/models/concerns/moveable_attachment.rb
+++ b/app/models/concerns/moveable_attachment.rb
@@ -26,7 +26,7 @@ module MoveableAttachment
 
     def move_attachment(from:, to:)
       FileUtils.makedirs(to)
-      FileUtils.mv(from, to, force: true)
+      system "mv -f #{from} #{to}"
     end
   end
 end

--- a/app/models/observation_document.rb
+++ b/app/models/observation_document.rb
@@ -17,9 +17,13 @@
 class ObservationDocument < ApplicationRecord
   has_paper_trail
   mount_base64_uploader :attachment, ObservationDocumentUploader
+  include MoveableAttachment
 
   acts_as_paranoid
 
   belongs_to :user, inverse_of: :observation_documents, touch: true
   belongs_to :observation, inverse_of: :observation_documents, touch: true
+
+  after_destroy :move_attachment_to_private_directory
+  after_restore :move_attachment_to_public_directory
 end

--- a/app/models/observation_report.rb
+++ b/app/models/observation_report.rb
@@ -33,23 +33,23 @@ class ObservationReport < ApplicationRecord
   private
 
   def move_attachment_to_private_directory
-    move_attachment(
-      from: File.join('public', 'uploads', self.class.to_s.underscore, 'attachment', id.to_s),
-      to: File.join('private_uploads', self.class.to_s.underscore, 'attachment')
-    )
+    return unless attachment
+
+    from = File.dirname(attachment.file.file.gsub('/private/', '/public/'))
+    to = File.dirname(from.gsub('/public/', '/private/'))
+    move_attachment(from: from, to: to)
   end
 
   def move_attachment_to_public_directory
-    move_attachment(
-      from: File.join('private_uploads', self.class.to_s.underscore, 'attachment', id.to_s),
-      to: File.join('public', 'uploads', self.class.to_s.underscore, 'attachment')
-    )
+    return unless attachment
+
+    from = File.dirname(attachment.file.file.gsub('/public/', '/private/'))
+    to = File.dirname(from.gsub('/private/', '/public/'))
+    move_attachment(from: from, to: to)
   end
 
   def move_attachment(from:, to:)
-    return unless attachment
-
     FileUtils.makedirs(to)
-    FileUtils.mv(from, to)
+    FileUtils.mv(from, to, force: true)
   end
 end

--- a/app/models/observation_report.rb
+++ b/app/models/observation_report.rb
@@ -17,6 +17,7 @@
 class ObservationReport < ApplicationRecord
   has_paper_trail
   mount_base64_uploader :attachment, ObservationReportUploader
+  include MoveableAttachment
 
   acts_as_paranoid
 
@@ -29,27 +30,4 @@ class ObservationReport < ApplicationRecord
   after_restore :move_attachment_to_public_directory
 
   scope :bigger_date, ->(date) { where('observation_reports.created_at <= ?', date + 1.day) }
-
-  private
-
-  def move_attachment_to_private_directory
-    return unless attachment
-
-    from = File.dirname(attachment.file.file.gsub('/private/', '/public/'))
-    to = File.dirname(from.gsub('/public/', '/private/'))
-    move_attachment(from: from, to: to)
-  end
-
-  def move_attachment_to_public_directory
-    return unless attachment
-
-    from = File.dirname(attachment.file.file.gsub('/public/', '/private/'))
-    to = File.dirname(from.gsub('/private/', '/public/'))
-    move_attachment(from: from, to: to)
-  end
-
-  def move_attachment(from:, to:)
-    FileUtils.makedirs(to)
-    FileUtils.mv(from, to, force: true)
-  end
 end

--- a/app/models/observation_report.rb
+++ b/app/models/observation_report.rb
@@ -21,9 +21,9 @@ class ObservationReport < ApplicationRecord
   acts_as_paranoid
 
   belongs_to :user, inverse_of: :observation_reports
-  has_many :observation_report_observers
+  has_many :observation_report_observers, dependent: :destroy
   has_many :observers, through: :observation_report_observers
-  has_many :observations
+  has_many :observations, dependent: :destroy
 
   after_destroy :move_attachment_to_private_directory
   after_restore :move_attachment_to_public_directory

--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -3,12 +3,35 @@
 class ApplicationUploader < CarrierWave::Uploader::Base
   storage :file
 
+  def root
+    result = super
+    result = Rails.root.join('private') if private_upload?
+    result = result.to_s.gsub(Rails.root.to_s, Rails.root.join('tmp').to_s) if Rails.env.test?
+    result
+  end
+
+  def cache_dir
+    return Rails.root.join('tmp', 'uploads', 'cache') if Rails.env.test?
+
+    super
+  end
+
+  def url
+    return "/private#{super}" if private_upload?
+
+    super
+  end
+
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
   def exists?
     file.present?
+  end
+
+  def private_upload?
+    false
   end
 
   def original_filename

--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ApplicationUploader < CarrierWave::Uploader::Base
+  storage :file
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def exists?
+    file.present?
+  end
+
+  def original_filename
+    if file.present?
+      file.filename
+    else
+      super
+    end
+  end
+end

--- a/app/uploaders/document_file_uploader.rb
+++ b/app/uploaders/document_file_uploader.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
-class DocumentFileUploader < CarrierWave::Uploader::Base
-  storage :file
-
+class DocumentFileUploader < ApplicationUploader
   def store_dir
     "uploads/operator_document_file/#{mounted_as}/#{model.id}"
   end
 
   def extension_whitelist
     %w(pdf doc docx txt csv xml jpg jpeg png exif tiff bmp)
-  end
-
-  def exists?
-    file.present?
   end
 
   def filename
@@ -26,13 +20,5 @@ class DocumentFileUploader < CarrierWave::Uploader::Base
     ].compact.join('-')
 
     filename + File.extname(super)
-  end
-
-  def original_filename
-    if file.present?
-      file.filename
-    else
-      super
-    end
   end
 end

--- a/app/uploaders/document_uploader.rb
+++ b/app/uploaders/document_uploader.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
-class DocumentUploader < CarrierWave::Uploader::Base
-  storage :file
-
+class DocumentUploader < ApplicationUploader
   def store_dir
     "uploads/documents/#{model.id}"
   end
 
   def extension_whitelist
     %w(pdf doc docx txt csv xml jpg jpeg png exif tiff bmp)
-  end
-
-  def exists?
-    file.present?
   end
 end

--- a/app/uploaders/gov_document_uploader.rb
+++ b/app/uploaders/gov_document_uploader.rb
@@ -1,18 +1,8 @@
 # frozen_string_literal: true
 
-class GovDocumentUploader < CarrierWave::Uploader::Base
-  storage :file
-
-  def store_dir
-    "uploads/gov_document/#{model.gov_document.id}/#{model.id}"
-  end
-
+class GovDocumentUploader < ApplicationUploader
   def extension_whitelist
     %w(pdf doc docx txt csv xml jpg jpeg png exif tiff bmp)
-  end
-
-  def exists?
-    file.present?
   end
 
   def filename
@@ -21,13 +11,5 @@ class GovDocumentUploader < CarrierWave::Uploader::Base
     filename = '' + model.gov_document.required_gov_document.name + '-' + Date.today.to_s
     filename += '.' + super.split('.').last if super.split('.').any?
     filename
-  end
-
-  def original_filename
-    if file.present?
-      file.filename
-    else
-      super
-    end
   end
 end

--- a/app/uploaders/logo_uploader.rb
+++ b/app/uploaders/logo_uploader.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
-class LogoUploader < CarrierWave::Uploader::Base
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
+class LogoUploader < ApplicationUploader
   include CarrierWave::MiniMagick
-
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
-
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
 
   def extension_whitelist
     %w(jpg jpeg gif png)
@@ -40,17 +28,5 @@ class LogoUploader < CarrierWave::Uploader::Base
   # This is just for active admin
   version :original do
     process resize_to_fill: [80, 80]
-  end
-
-  def exists?
-    file.present?
-  end
-
-  def original_filename
-    if file.present?
-      file.filename
-    else
-      super
-    end
   end
 end

--- a/app/uploaders/observation_document_uploader.rb
+++ b/app/uploaders/observation_document_uploader.rb
@@ -20,4 +20,8 @@ class ObservationDocumentUploader < ApplicationUploader
 
     filename + File.extname(super)
   end
+
+  def private_upload?
+    model.deleted?
+  end
 end

--- a/app/uploaders/observation_document_uploader.rb
+++ b/app/uploaders/observation_document_uploader.rb
@@ -1,18 +1,8 @@
 # frozen_string_literal: true
 
-class ObservationDocumentUploader < CarrierWave::Uploader::Base
-  storage :file
-
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
+class ObservationDocumentUploader < ApplicationUploader
   def extension_whitelist
     %w(pdf doc docx txt csv xml jpg jpeg png exif tiff bmp)
-  end
-
-  def exists?
-    file.present?
   end
 
   def filename
@@ -29,13 +19,5 @@ class ObservationDocumentUploader < CarrierWave::Uploader::Base
                end
 
     filename + File.extname(super)
-  end
-
-  def original_filename
-    if file.present?
-      file.filename
-    else
-      super
-    end
   end
 end

--- a/app/uploaders/observation_report_uploader.rb
+++ b/app/uploaders/observation_report_uploader.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class ObservationReportUploader < CarrierWave::Uploader::Base
-  storage :file
-
+class ObservationReportUploader < ApplicationUploader
   def store_dir
     directory = model.deleted? ? 'private_uploads' : 'uploads'
     "#{directory}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
@@ -18,10 +16,6 @@ class ObservationReportUploader < CarrierWave::Uploader::Base
     %w(pdf doc docx txt csv xml jpg jpeg png exif tiff bmp)
   end
 
-  def exists?
-    file.present?
-  end
-
   def filename
     return if super.blank?
 
@@ -29,13 +23,5 @@ class ObservationReportUploader < CarrierWave::Uploader::Base
     filename = '' + model.title[0...50]&.parameterize + '-' + date
     filename += '.' + super.split('.').last if super.split('.').any?
     filename
-  end
-
-  def original_filename
-    if file.present?
-      file.filename
-    else
-      super
-    end
   end
 end

--- a/app/uploaders/observation_report_uploader.rb
+++ b/app/uploaders/observation_report_uploader.rb
@@ -1,40 +1,18 @@
 # frozen_string_literal: true
 
 class ObservationReportUploader < CarrierWave::Uploader::Base
-
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
-
-  # Choose what kind of storage to use for this uploader:
   storage :file
-  # storage :fog
 
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    directory = model.deleted? ? 'private_uploads' : 'uploads'
+    "#{directory}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-  # end
+  def root
+    return Rails.root if model.deleted?
 
-  # Process files as they are uploaded:
-  # process scale: [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
+    Rails.root.join('public')
+  end
 
   def extension_whitelist
     %w(pdf doc docx txt csv xml jpg jpeg png exif tiff bmp)

--- a/app/uploaders/observation_report_uploader.rb
+++ b/app/uploaders/observation_report_uploader.rb
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
 class ObservationReportUploader < ApplicationUploader
-  def store_dir
-    directory = model.deleted? ? 'private_uploads' : 'uploads'
-    "#{directory}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
-  def root
-    return Rails.root if model.deleted?
-
-    Rails.root.join('public')
-  end
-
   def extension_whitelist
     %w(pdf doc docx txt csv xml jpg jpeg png exif tiff bmp)
   end
@@ -23,5 +12,9 @@ class ObservationReportUploader < ApplicationUploader
     filename = '' + model.title[0...50]&.parameterize + '-' + date
     filename += '.' + super.split('.').last if super.split('.').any?
     filename
+  end
+
+  def private_upload?
+    model.deleted?
   end
 end

--- a/app/uploaders/operator_document_annex_uploader.rb
+++ b/app/uploaders/operator_document_annex_uploader.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
-class OperatorDocumentAnnexUploader < CarrierWave::Uploader::Base
-  storage :file
-
+class OperatorDocumentAnnexUploader < ApplicationUploader
   def store_dir
     "uploads/operator_document_annex/#{mounted_as}/#{model.id}"
   end
 
   def extension_whitelist
     %w(pdf doc docx txt csv xml jpg jpeg png exif tiff bmp)
-  end
-
-  def exists?
-    file.present?
   end
 
   def filename
@@ -22,13 +16,5 @@ class OperatorDocumentAnnexUploader < CarrierWave::Uploader::Base
     filename = "Annex_#{Time.now.to_i}_" + suffix
     filename += '.' + super.split('.').last if super.split('.').any?
     filename
-  end
-
-  def original_filename
-    if file.present?
-      file.filename
-    else
-      super
-    end
   end
 end

--- a/app/uploaders/partner_logo_uploader.rb
+++ b/app/uploaders/partner_logo_uploader.rb
@@ -1,18 +1,7 @@
 # frozen_string_literal: true
 
-class PartnerLogoUploader < CarrierWave::Uploader::Base
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
+class PartnerLogoUploader < ApplicationUploader
   include CarrierWave::MiniMagick
-
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
 
   def extension_whitelist
     %w(jpg jpeg gif png svg tiff)
@@ -27,17 +16,5 @@ class PartnerLogoUploader < CarrierWave::Uploader::Base
   # This is just for active admin
   version :original do
     process resize_to_fill: [80, 80]
-  end
-
-  def exists?
-    file.present?
-  end
-
-  def original_filename
-    if file.present?
-      file.filename
-    else
-      super
-    end
   end
 end

--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -2,20 +2,8 @@
 
 require 'carrierwave/processing/mini_magick'
 
-class PhotoUploader < CarrierWave::Uploader::Base
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
+class PhotoUploader < ApplicationUploader
   include CarrierWave::MiniMagick
-
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
-
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
 
   def extension_whitelist
     %w(jpg jpeg gif png)
@@ -42,17 +30,5 @@ class PhotoUploader < CarrierWave::Uploader::Base
   # This is just for active admin
   version :original do
     process resize_to_fill: [80, 80]
-  end
-
-  def exists?
-    file.present?
-  end
-
-  def original_filename
-    if file.present?
-      file.filename
-    else
-      super
-    end
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,7 @@ set :rvm_roles, [:app, :web, :db]
 set :keep_releases, 5
 
 set :linked_files, %w{.env}
-set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/uploads}
+set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/uploads private}
 
 set :rvm_map_bins, fetch(:rvm_map_bins, []).push('rvmsudo')
 

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,26 +1,10 @@
 # frozen_string_literal: true
 
-if Rails.env.test?
-  CarrierWave.configure do |config|
+CarrierWave.configure do |config|
+  config.asset_host = ActionController::Base.asset_host
+
+  if Rails.env.test?
     config.storage           = :file
     config.enable_processing = false
   end
-
-  CarrierWave::Uploader::Base.descendants.each do |klass|
-    next if klass.anonymous?
-
-    klass.class_eval do
-      def cache_dir
-        Rails.root.join('spec', 'support', 'uploads', 'tmp')
-      end
-
-      def store_dir
-        Rails.root.join('spec', 'support', 'uploads', "#{model.class.to_s.underscore}", "#{mounted_as}", "#{model.id}")
-      end
-    end
-  end
-end
-
-CarrierWave.configure do |config|
-  config.asset_host = ActionController::Base.asset_host
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/admin/sidekiq'
   end
 
+  get '/private_uploads/*rest', controller: 'private_uploads', action: 'download'
+
   scope module: :v1, constraints: APIVersion.new(version: 1, current: true) do
     # Account
     post  '/login',                       to: 'sessions#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/admin/sidekiq'
   end
 
-  get '/private_uploads/*rest', controller: 'private_uploads', action: 'download'
+  get '/private/uploads/*rest', controller: 'private_uploads', action: 'download'
 
   scope module: :v1, constraints: APIVersion.new(version: 1, current: true) do
     # Account

--- a/spec/integration/private_uploads_spec.rb
+++ b/spec/integration/private_uploads_spec.rb
@@ -1,21 +1,12 @@
 require 'rails_helper'
 
-describe 'Private Uploads', type: :request do
+describe 'Private Uploads', :realistic_error_responses, type: :request do
   let(:admin) { create(:admin) }
 
   before do
     @observation_report = create(:observation_report)
     @observation_report.destroy!
     @observation_report.reload
-    @old_show_exceptions_value = Rails.application.config.action_dispatch.show_exceptions
-    @old_consider_all_requests_local_value = Rails.application.config.consider_all_requests_local
-    Rails.application.config.action_dispatch.show_exceptions = true
-    Rails.application.config.consider_all_requests_local = false
-  end
-
-  after do
-    Rails.application.config.action_dispatch.show_exceptions = @old_show_exceptions_value
-    Rails.application.config.consider_all_requests_local = @old_consider_all_requests_local_value
   end
 
   context 'as admin user' do

--- a/spec/integration/private_uploads_spec.rb
+++ b/spec/integration/private_uploads_spec.rb
@@ -8,11 +8,14 @@ describe 'Private Uploads', type: :request do
     @observation_report.destroy!
     @observation_report.reload
     @old_show_exceptions_value = Rails.application.config.action_dispatch.show_exceptions
+    @old_consider_all_requests_local_value = Rails.application.config.consider_all_requests_local
     Rails.application.config.action_dispatch.show_exceptions = true
+    Rails.application.config.consider_all_requests_local = false
   end
 
   after do
     Rails.application.config.action_dispatch.show_exceptions = @old_show_exceptions_value
+    Rails.application.config.consider_all_requests_local = @old_consider_all_requests_local_value
   end
 
   context 'as admin user' do

--- a/spec/integration/private_uploads_spec.rb
+++ b/spec/integration/private_uploads_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe 'Private Uploads', type: :request do
+  let(:admin) { create(:admin) }
+
+  before do
+    @observation_report = create(:observation_report)
+    @observation_report.destroy!
+    @observation_report.reload
+    @old_show_exceptions_value = Rails.application.config.action_dispatch.show_exceptions
+    Rails.application.config.action_dispatch.show_exceptions = true
+  end
+
+  after do
+    Rails.application.config.action_dispatch.show_exceptions = @old_show_exceptions_value
+  end
+
+  context 'as admin user' do
+    before { sign_in admin }
+
+    context 'with valid parameters' do
+      before { get @observation_report.attachment.url }
+
+      it 'downloads expected file' do
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'with wrong parameters' do
+      before { get '/private/uploads/../../../file' }
+
+      it 'returns error' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  context 'as not admin user' do
+    context 'with valid parameters' do
+      before { get @observation_report.attachment.url }
+
+      it 'does not download expected file' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/models/observation_document_spec.rb
+++ b/spec/models/observation_document_spec.rb
@@ -15,8 +15,36 @@
 require 'rails_helper'
 
 RSpec.describe ObservationDocument, type: :model do
+  subject { build(:observation_document) }
+
   it 'is valid with valid attributes' do
-    observation_document = build(:observation_document)
-    expect(observation_document).to be_valid
+    expect(subject).to be_valid
+  end
+
+  describe 'soft delete' do
+    let!(:report) { create(:observation_document) }
+
+    context 'when deleting' do
+      it 'moves attachment to private directory' do
+        expect(report.attachment.file.file).to match('/public/uploads')
+        report.destroy!
+        report.reload
+        expect(report.attachment.file.file).to match('/private/uploads')
+      end
+    end
+
+    context 'when restoring' do
+      before do
+        report.destroy!
+        report.reload
+      end
+
+      it 'moves attachment back to public directory' do
+        expect(report.attachment.file.file).to match('/private/uploads')
+        report.restore
+        report.reload
+        expect(report.attachment.file.file).to match('/public/uploads')
+      end
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -91,5 +91,7 @@ RSpec.configure do |config|
   config.extend APIDocsHelpers
   config.include FactoryBot::Syntax::Methods
   config.order = 'random'
-  config.include Devise::Test::ControllerHelpers, :type => :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Warden::Test::Helpers
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,6 +54,7 @@ RspecApiDocumentation.configure do |config|
 end
 
 RSpec.configure do |config|
+  config.include ErrorResponses
   config.include IntegrationHelper, type: :request
   config.include ImporterHelper, type: :importer
   config.extend APIDocsHelpers
@@ -75,6 +76,10 @@ RSpec.configure do |config|
     if Rails.env.test? || Rails.env.cucumber?
       FileUtils.rm_rf(Dir["#{Rails.root}/spec/support/uploads"])
     end
+  end
+
+  config.around(realistic_error_responses: true) do |example|
+    respond_without_detailed_exceptions(&example)
   end
 
   if Bullet.enable?

--- a/spec/support/error_responses.rb
+++ b/spec/support/error_responses.rb
@@ -1,0 +1,14 @@
+# https://eliotsykes.com/2017/03/08/realistic-error-responses/
+module ErrorResponses
+  def respond_without_detailed_exceptions
+    env_config = Rails.application.env_config
+    original_show_exceptions = env_config['action_dispatch.show_exceptions']
+    original_show_detailed_exceptions = env_config['action_dispatch.show_detailed_exceptions']
+    env_config['action_dispatch.show_exceptions'] = true
+    env_config['action_dispatch.show_detailed_exceptions'] = false
+    yield
+  ensure
+    env_config['action_dispatch.show_exceptions'] = original_show_exceptions
+    env_config['action_dispatch.show_detailed_exceptions'] = original_show_detailed_exceptions
+  end
+end


### PR DESCRIPTION

- Add the option for admins to delete IM reports in the Reports menu.
- Add a warning message when deleting the report if there are observations associated (in same way as it has been adding to the Producers menu).
- Deleted reports should go into the already existing recycling bin.
- Option to hard-delete reports
- Add the option for admins to delete and to edit evidence files in the Evidence menu.
- Options to hard-delete evidences

When soft-deleting reports or evidences the files are moved to `private` directory which is accessible only to admins.

https://www.pivotaltracker.com/story/show/181286826

TODO
- [x] one time script to move already deleted observation documents to private directory