### PR TITLE
Add job for updating country translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'sidekiq'
 
 # Data
 gem 'activerecord-import'
+gem 'countries', require: false # for update translations job, so require only there
 gem 'globalize', '5.1.0'
 gem 'seed-fu'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
+    countries (5.1.1)
+      sixarm_ruby_unaccent (~> 1.1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -481,6 +483,7 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sixarm_ruby_unaccent (1.2.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -552,6 +555,7 @@ DEPENDENCIES
   capistrano-rvm
   carrierwave-base64
   chartkick
+  countries
   database_cleaner
   devise
   dotenv-rails

--- a/lib/tasks/countries.rake
+++ b/lib/tasks/countries.rake
@@ -1,0 +1,25 @@
+require 'countries/iso3166'
+
+namespace :countries do
+  desc 'Update existing country translations using countries gem'
+  task update_translations: :environment do
+    for_real = ENV['FOR_REAL'] == 'true'
+    puts "DRY RUN" unless for_real
+
+    Country.find_each do |country|
+      (I18n.available_locales - [:en]).map do |locale|
+        I18n.with_locale(locale) do
+          country_metadata = ISO3166::Country.find_country_by_alpha3(country.iso)
+          if country_metadata.nil?
+            puts "ERROR: no country metadata for #{country.iso}"
+            next
+          end
+
+          new_name = country_metadata.translation(locale)
+          puts "locale: #{locale} updating #{country.iso} name: #{country.name} to: #{new_name}"
+          country.update!(name: new_name) if for_real
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We don't have all translations for countries for all available languages. This PR adds a job that will deal with it, I need full list of countries with correct translations for newsletter page, also it would be good to have correct translations for active countries on the rest of pages as well.