### PR TITLE
Feature/about page entries code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'sidekiq'
 
 # Data
 gem 'activerecord-import'
+gem 'acts_as_list'
 gem 'countries', require: false # for update translations job, so require only there
 gem 'globalize', '5.1.0'
 gem 'seed-fu'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts_as_list (1.0.4)
+      activerecord (>= 4.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.1)
@@ -541,6 +543,7 @@ DEPENDENCIES
   activeadmin_quill_editor
   activerecord-import
   activerecord-postgis-adapter
+  acts_as_list
   annotate
   bcrypt
   brakeman

--- a/app/admin/about_page_entries.rb
+++ b/app/admin/about_page_entries.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register AboutPageEntry do
 
   menu false
 
-  config.order_clause
+  config.sort_order = 'position_asc'
 
   permit_params :position, :code, translations_attributes: [:id, :locale, :title, :body, :_destroy]
 
@@ -50,8 +50,8 @@ ActiveAdmin.register AboutPageEntry do
   form do |f|
     f.semantic_errors *f.object.errors.keys
     f.inputs 'About Page Entries' do
-      f.input :position
-      f.input :code
+      f.input :position, hint: 'leaving empty will assign last position'
+      f.input :code, hint: 'must be "partners" for Partners and "donors" for Donors section'
     end
     f.translated_inputs switch_locale: false do |t|
       t.input :title

--- a/app/admin/about_page_entries.rb
+++ b/app/admin/about_page_entries.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register AboutPageEntry do
 
   config.order_clause
 
-  permit_params :position, translations_attributes: [:id, :locale, :title, :body, :_destroy]
+  permit_params :position, :code, translations_attributes: [:id, :locale, :title, :body, :_destroy]
 
   filter :position, as: :select
   filter :translations_title_contains, as: :select, label: 'Title',
@@ -26,6 +26,7 @@ ActiveAdmin.register AboutPageEntry do
   csv do
     column :position
     column :title
+    column :code
     column :body
     column :created_at
     column :updated_at
@@ -34,6 +35,7 @@ ActiveAdmin.register AboutPageEntry do
   index do
     column :position
     column :title
+    column :code
     # rubocop:disable Rails/OutputSafety
     column :body do |entry|
       entry.body.html_safe
@@ -49,6 +51,7 @@ ActiveAdmin.register AboutPageEntry do
     f.semantic_errors *f.object.errors.keys
     f.inputs 'About Page Entries' do
       f.input :position
+      f.input :code
     end
     f.translated_inputs switch_locale: false do |t|
       t.input :title
@@ -74,6 +77,7 @@ ActiveAdmin.register AboutPageEntry do
     attributes_table do
       row :position
       row :title
+      row :code
       # rubocop:disable Rails/OutputSafety
       row :body do |entry|
         entry.body.html_safe

--- a/app/models/about_page_entry.rb
+++ b/app/models/about_page_entry.rb
@@ -10,11 +10,10 @@
 #  updated_at :datetime         not null
 #
 class AboutPageEntry < ApplicationRecord
+  acts_as_list
+
   include Translatable
   translates :title, :body, touch: true
-
-  validates_uniqueness_of :position
-  validates_presence_of :position
 
   active_admin_translates :title do
     validates_presence_of :title

--- a/app/resources/v1/about_page_entry_resource.rb
+++ b/app/resources/v1/about_page_entry_resource.rb
@@ -6,7 +6,7 @@ module V1
     immutable
     caching
 
-    attributes :position, :title, :body
+    attributes :position, :title, :body, :code
 
     def self.default_sort
       [{ field: :position, direction: :asc }]

--- a/db/migrate/20220925103640_add_code_to_about_page_entries.rb
+++ b/db/migrate/20220925103640_add_code_to_about_page_entries.rb
@@ -1,0 +1,5 @@
+class AddCodeToAboutPageEntries < ActiveRecord::Migration[5.0]
+  def change
+    add_column :about_page_entries, :code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220803123657) do
+ActiveRecord::Schema.define(version: 20220925103640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "postgis"
   enable_extension "address_standardizer"
   enable_extension "address_standardizer_data_us"
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
+  enable_extension "postgis"
   enable_extension "postgis_tiger_geocoder"
   enable_extension "postgis_topology"
 
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20220803123657) do
     t.integer  "position",   null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "code"
     t.index ["position"], name: "index_about_page_entries_on_position", using: :btree
   end
 

--- a/spec/factories/about_page_entries.rb
+++ b/spec/factories/about_page_entries.rb
@@ -15,5 +15,6 @@ FactoryBot.define do
     sequence :position
     title { 'Title' }
     body { 'Body' }
+    code { 'body' }
   end
 end

--- a/spec/integration/v1/about_page_entries_spec.rb
+++ b/spec/integration/v1/about_page_entries_spec.rb
@@ -7,10 +7,6 @@ module V1
         locales: [:en, :fr],
         attributes: { title: 'Title', body: 'Body' }
       },
-      sort: {
-        attribute: :position,
-        sequence: -> (i) { i }
-      },
       route_key: 'about-page-entries'
     }
   end


### PR DESCRIPTION
- adding `code` to about page entries, to distinguish `donors` and `partners`
- adding `acts_as_list` gem for better admin position manipulation