### PR TITLE
Change sorting column in admin panel to prevent server crash

### DIFF
--- a/app/admin/operator_document.rb
+++ b/app/admin/operator_document.rb
@@ -183,22 +183,22 @@ ActiveAdmin.register OperatorDocument do
     column :country do |od|
       od.required_operator_document.country
     end
-    column 'Required Document', :required_operator_document, sortable: 'required_operator_documents.name' do |od|
+    column 'Required Document', :required_operator_document, sortable: 'required_operator_document_id' do |od|
       if od.required_operator_document.present?
         link_to od.required_operator_document.name, admin_required_operator_document_path(od.required_operator_document)
       else
         RequiredOperatorDocument.unscoped.find(od.required_operator_document_id).name
       end
     end
-    column :Type, sortable: 'required_operator_documents.type' do |od|
+    column :Type, sortable: false do |od|
       if od.required_operator_document.present?
         od.required_operator_document.type == 'RequiredOperatorDocumentFmu' ? 'Fmu' : 'Operator'
       else
         RequiredOperatorDocument.unscoped.find(od.required_operator_document_id).type
       end
     end
-    column :operator, sortable: 'operator_translations.name'
-    column :fmu, sortable: 'fmu_translations.name'
+    column :operator, sortable: 'operator_id'
+    column :fmu, sortable: 'fmu_id'
     column 'Legal Category' do |od|
       if od.required_operator_document.present?
         od.required_operator_document.required_operator_document_group.name
@@ -206,7 +206,7 @@ ActiveAdmin.register OperatorDocument do
         RequiredOperatorDocument.unscoped.find(od.required_operator_document_id).required_operator_document_group.name
       end
     end
-    column :user, sortable: 'users.name'
+    column :user, sortable: 'user_id'
     column :expire_date
     column :start_date
     column :created_at

--- a/app/admin/operator_document_history.rb
+++ b/app/admin/operator_document_history.rb
@@ -88,14 +88,14 @@ ActiveAdmin.register OperatorDocumentHistory do
     column :country do |od|
       od.required_operator_document.country
     end
-    column 'Required Document', :required_operator_document, sortable: 'required_operator_documents.name' do |od|
+    column 'Required Document', :required_operator_document, sortable: 'required_operator_document_id' do |od|
       if od.required_operator_document.present?
         link_to od.required_operator_document.name, admin_required_operator_document_path(od.required_operator_document)
       else
         RequiredOperatorDocument.unscoped.find(od.required_operator_document_id).name
       end
     end
-    column :Type, sortable: 'required_operator_documents.type' do |od|
+    column :Type, sortable: false do |od|
       if od.required_operator_document.present?
         od.required_operator_document.type == 'RequiredOperatorDocumentFmu' ? 'Fmu' : 'Operator'
       else


### PR DESCRIPTION
I think that this is because the old version of active admin which uses old version of ransack. When sorting by for example countries_translations.name in operator LIMIT and OFFSET is removed from query what is causing the whole dataset to load.