### PR TITLE
Fix saving documents with annex documents

### DIFF
--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -38,7 +38,7 @@ class OperatorDocument < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :document_file, optional: true, inverse_of: :operator_document
 
-  has_many :annex_documents, as: :documentable, dependent: :destroy
+  has_many :annex_documents, as: :documentable, dependent: :destroy, inverse_of: :documentable
   has_many :operator_document_annexes, through: :annex_documents
   has_many :notifications
   accepts_nested_attributes_for :document_file

--- a/app/models/operator_document_history.rb
+++ b/app/models/operator_document_history.rb
@@ -37,7 +37,7 @@ class OperatorDocumentHistory < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :document_file, optional: true
   belongs_to :operator_document, -> { with_deleted }
-  has_many :annex_documents, as: :documentable
+  has_many :annex_documents, as: :documentable, inverse_of: :documentable
   has_many :operator_document_annexes, through: :annex_documents
 
   scope :fmu_type,                               -> { where(type: 'OperatorDocumentFmuHistory') }


### PR DESCRIPTION
It was not possible to save operator document as created history was invalid with error saying annex document documentable does not exist. 

This is hot-fix so it's already on production.