### PR TITLE
Fix redirect back in admin panel

### DIFF
--- a/app/admin/observation_document.rb
+++ b/app/admin/observation_document.rb
@@ -19,9 +19,9 @@ ActiveAdmin.register ObservationDocument, as: 'Evidence' do
   member_action :really_destroy, method: :delete do
     if resource.deleted?
       resource.really_destroy!
-      redirect_to :back, notice: 'Evidence removed!'
+      redirect_back fallback_location: admin_evidences_path, notice: 'Evidence removed!'
     else
-      redirect_to :back, notice: 'Evidence must be moved to recycle bin first!'
+      redirect_back fallback_location: admin_evidences_path, notice: 'Evidence must be moved to recycle bin first!'
     end
   end
 

--- a/app/admin/observation_report.rb
+++ b/app/admin/observation_report.rb
@@ -30,9 +30,9 @@ ActiveAdmin.register ObservationReport do
   member_action :really_destroy, method: :delete do
     if resource.deleted?
       resource.really_destroy!
-      redirect_to :back, notice: 'Report removed!'
+      redirect_back fallback_location: admin_observation_report_path, notice: 'Report removed!'
     else
-      redirect_to :back, notice: 'Report must be moved to recycle bin first!'
+      redirect_back fallback_location: admin_observation_report_path, notice: 'Report must be moved to recycle bin first!'
     end
   end
 

--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -18,12 +18,12 @@ ActiveAdmin.register Operator, as: 'Producer' do
 
   member_action :activate, method: :put do
     resource.update(is_active: true)
-    redirect_to :back, notice: 'Producer activated'
+    redirect_back fallback_location: admin_producers_path, notice: 'Producer activated'
   end
 
   member_action :deactivate, method: :put do
     resource.update(is_active: false)
-    redirect_to :back, notice: 'Producer deactivated'
+    redirect_back fallback_location: admin_producers_path, notice: 'Producer deactivated'
   end
 
   config.clear_action_items!

--- a/spec/controllers/admin/observation_documents_controller_spec.rb
+++ b/spec/controllers/admin/observation_documents_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+# Base specs for admin default actions are done in active_admin_spec.rb
+RSpec.describe Admin::EvidencesController, type: :controller do
+  let(:admin) { create(:admin) }
+
+  render_views
+
+  before { sign_in admin }
+
+  describe 'DELETE really_destroy' do
+    let!(:observation_document) { create(:observation_document) }
+
+    subject { delete :really_destroy, params: {id: observation_document.id} }
+
+    context 'when document not soft deleted' do
+      before do
+        expect { subject }.not_to change { ObservationDocument.unscoped.count }
+      end
+
+      it 'displays error message to move to recycle bin first' do
+        expect(flash[:notice]).to match('Evidence must be moved to recycle bin first!')
+      end
+    end
+
+    context 'when document soft deleted' do
+      before do
+        observation_document.destroy!
+        expect { subject }.to change { ObservationDocument.unscoped.count }.by(-1)
+      end
+
+      it 'is successful' do
+        expect(flash[:notice]).to match('Evidence removed!')
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/observation_reports_controller_spec.rb
+++ b/spec/controllers/admin/observation_reports_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+# Base specs for admin default actions are done in active_admin_spec.rb
+RSpec.describe Admin::ObservationReportsController, type: :controller do
+  let(:admin) { create(:admin) }
+
+  render_views
+
+  before { sign_in admin }
+
+  describe 'DELETE really_destroy' do
+    let!(:observation_report) { create(:observation_report) }
+
+    subject { delete :really_destroy, params: {id: observation_report.id} }
+
+    context 'when report not soft deleted' do
+      before do
+        expect { subject }.not_to change { ObservationReport.unscoped.count }
+      end
+
+      it 'displays error message to move to recycle bin first' do
+        expect(flash[:notice]).to match('Report must be moved to recycle bin first!')
+      end
+    end
+
+    context 'when report soft deleted' do
+      before do
+        observation_report.destroy!
+        expect { subject }.to change { ObservationReport.unscoped.count }.by(-1)
+      end
+
+      it 'is successful' do
+        expect(flash[:notice]).to match('Report removed!')
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/operators_controller_spec.rb
+++ b/spec/controllers/admin/operators_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+# Base specs for admin default actions are done in active_admin_spec.rb
+RSpec.describe Admin::ProducersController, type: :controller do
+  let(:admin) { create(:admin) }
+
+  render_views
+
+  before { sign_in admin }
+
+  describe 'PUT activate' do
+    let!(:operator) { create(:operator, is_active: false) }
+
+    subject { put :activate, params: {id: operator.id} }
+
+    before { subject }
+
+    it 'is successful' do
+      expect(flash[:notice]).to match('Producer activated')
+      expect(operator.reload.is_active).to be(true)
+    end
+  end
+
+  describe 'PUT deactivate' do
+    let!(:operator) { create(:operator, is_active: true) }
+
+    subject { put :deactivate, params: {id: operator.id} }
+
+    before { subject }
+
+    it 'is successful' do
+      expect(flash[:notice]).to match('Producer deactivated')
+      expect(operator.reload.is_active).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
I just discovered that in Rails 5.1 there is no `redirect :back` and specs were not catching any of those mistakes. I'm adding missing specs and fixing all places to have proper back redirection.