### PR TITLE
Change how expiration works for documents based on different statuses

### DIFF
--- a/app/models/gov_document.rb
+++ b/app/models/gov_document.rb
@@ -89,7 +89,8 @@ class GovDocument < ApplicationRecord
   end
 
   def expire_document
-    self.update(status: GovDocument.statuses[:doc_expired])
+    destroy! if status == 'doc_not_required'
+    update!(status: 'doc_expired') if status == 'doc_valid'
   end
 
   def has_data?

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -123,7 +123,8 @@ class OperatorDocument < ApplicationRecord
   end
 
   def expire_document
-    self.update(status: OperatorDocument.statuses[:doc_expired])
+    destroy! if status == 'doc_not_required' # that would regenerate with not_provided state
+    update!(status: 'doc_expired') if status == 'doc_valid'
   end
 
   # When a doc is valid or not required

--- a/lib/tasks/fix_one_time.rake
+++ b/lib/tasks/fix_one_time.rake
@@ -247,13 +247,17 @@ namespace :fix_one_time do
       puts "FOUND #{docs.count} docs expired that were not required before"
       puts "DOC_IDS: #{docs.map(&:id).join(',')}"
 
+      operators = docs.map(&:operator).uniq
+      puts "OPERATORS:"
+      operators.each { |op| puts "#{op.name} (#{op.id})" }
+
       # that will regenerate documents to not provided state
       puts "REGENERATING DOCS..."
       docs.each do |doc|
         doc.skip_score_recalculation = true # just do it once for each operator at the end
         doc.destroy!
       end
-      docs.map(&:operator).uniq.each { |operator| ScoreOperatorDocument.recalculate!(operator) }
+      operators.each { |operator| ScoreOperatorDocument.recalculate!(operator) }
 
       if docs.each(&:reload).select { |d| d.status == 'doc_not_provided' }.count == docs_count
         puts "ALL GOOD :)"

--- a/lib/tasks/fix_one_time.rake
+++ b/lib/tasks/fix_one_time.rake
@@ -221,4 +221,47 @@ namespace :fix_one_time do
     puts "Missing files: #{missing}"
     puts "Moved files: #{moved}"
   end
+
+  desc 'Mark expired documents there were expired from not required state as not provided'
+  task not_required_expired_move_to_not_provided: :environment do
+    for_real = ENV['FOR_REAL'] == 'true'
+
+    puts "RUNNING FOR REAL" if for_real
+    puts "DRY RUN" unless for_real
+
+    ActiveRecord::Base.transaction do
+      docs = OperatorDocument
+        .where(status: 'doc_expired', updated_at: 1.month.ago..Date.today)
+        .select do |o|
+          prev_version_not_required = false
+          o.versions.reverse.each do |version|
+            next if version.reify.status == 'doc_expired'
+
+            prev_version_not_required = version.reify.status == 'doc_not_required'
+            break
+          end
+          prev_version_not_required
+        end
+
+      docs_count = docs.count
+      puts "FOUND #{docs.count} docs expired that were not required before"
+      puts "DOC_IDS: #{docs.map(&:id).join(',')}"
+
+      # that will regenerate documents to not provided state
+      puts "REGENERATING DOCS..."
+      docs.each do |doc|
+        doc.skip_score_recalculation = true # just do it once for each operator at the end
+        doc.destroy!
+      end
+      docs.map(&:operator).uniq.each { |operator| ScoreOperatorDocument.recalculate!(operator) }
+
+      if docs.each(&:reload).select { |d| d.status == 'doc_not_provided' }.count == docs_count
+        puts "ALL GOOD :)"
+      else
+        puts "ERROR: doc count after docs regenerate does not match"
+      end
+
+      raise ActiveRecord::Rollback unless for_real
+    end
+  end
 end

--- a/spec/models/gov_document_spec.rb
+++ b/spec/models/gov_document_spec.rb
@@ -46,7 +46,15 @@ RSpec.describe GovDocument, type: :model do
         context 'when the status is not required' do
           let(:status) { :doc_not_required }
 
-          it { expect { subject }.to change { gd.reload.status }.from('doc_not_required').to('doc_expired') }
+          it 'destroys old document, generates a new not provided one' do
+            expect { subject }.to \
+              change { GovDocument.unscoped.count }.by(1).and \
+              change { gd.reload.deleted? }.from(false).to(true).and \
+              change { gd.current }.from(true).to(false)
+
+            current_doc = GovDocument.find_by(required_gov_document: gd.required_gov_document, current: true)
+            expect(current_doc.status).to eq('doc_not_provided')
+          end
         end
 
         context 'when the status is pending' do


### PR DESCRIPTION
Not required documents should "expire" to "not provided" state. This PR also contains a quick fix for documents that expired but should be not provided.
