### PR TITLE
Fix old observations lat/lng

### DIFF
--- a/lib/tasks/fix_one_time.rake
+++ b/lib/tasks/fix_one_time.rake
@@ -159,36 +159,6 @@ namespace :fix_one_time do
     end
   end
 
-  desc 'Fixes the bug with wrong observation lnglat'
-  task observation_lnglat: :environment do
-    for_real = ENV['FOR_REAL'] == 'true'
-
-    puts "RUNNING FOR REAL" if for_real
-    puts "DRY RUN" unless for_real
-
-    observations = Observation.where.not(fmu: nil)
-    observations.find_each do |observation|
-      fmu_lng = observation.fmu.geojson.dig('properties', 'centroid', 'coordinates')&.first
-      fmu_lat = observation.fmu.geojson.dig('properties', 'centroid', 'coordinates')&.second
-
-      next if fmu_lng.nil? || fmu_lat.nil?
-
-      if observation.lng.nil? || observation.lat.nil?
-        puts "NO lng lat for #{observation.id}, fixing"
-
-        observation.lng = fmu_lng
-        observation.lat = fmu_lat
-        observation.save! if for_real
-      elsif observation.lng.round(3) == fmu_lat.round(3) && observation.lat.round(3) == fmu_lng.round(3)
-        puts "FOUND wrong lng lat for #{observation.id}, fixing"
-
-        observation.lng = fmu_lng
-        observation.lat = fmu_lat
-        observation.save! if for_real
-      end
-    end
-  end
-
   desc 'Tasks to move already deleted reports attachments and evidences to private directory'
   task make_deleted_evidences_private: :environment do
     for_real = ENV['FOR_REAL'] == 'true'

--- a/lib/tasks/observations.rake
+++ b/lib/tasks/observations.rake
@@ -99,6 +99,7 @@ namespace :observations do
     puts "#{results.count} results with swapped lng lat inside fmu"
     puts "Observation ids: #{results.map { |r| r['id'] }.join(', ')}"
     ActiveRecord::Base.transaction do
+      Observation.skip_callback(:save, :after, :update_fmu_geojson)
       results.each do |res|
         observation = Observation.find(res['id'])
         lng = observation.lat
@@ -106,6 +107,7 @@ namespace :observations do
         puts "Updating lng/lat for observation #{observation.id}"
         observation.update!(lng: lng, lat: lat)
       end
+      Observation.set_callback(:save, :after, :update_fmu_geojson)
 
       raise ActiveRecord::Rollback unless for_real
     end

--- a/lib/tasks/observations.rake
+++ b/lib/tasks/observations.rake
@@ -64,4 +64,52 @@ namespace :observations do
       observation.save!
     end
   end
+
+  desc 'Finds obs with swapped coords and fixing them'
+  task fix_swapped_coords: :environment do
+    for_real = ENV['FOR_REAL'] == 'true'
+
+    puts "RUNNING FOR REAL" if for_real
+    puts "DRY RUN" unless for_real
+
+    query = <<~SQL
+      select temp2.* from
+      (
+        select
+          temp.id,
+          temp.operator_id,
+          temp.operator_name,
+          ST_CONTAINS(geometry, point) as inside_fmu,
+          ST_CONTAINS(geometry, pointSwapped) as swapped_inside_fmu
+        from
+        (
+          select o.*, ot.name as operator_name, f.geometry,
+            ST_SetSRID(ST_POINT(o.lng, o.lat), 4326) as point,
+            ST_SetSRID(ST_POINT(o.lat, o.lng), 4326) as pointSwapped
+          from
+            observations o
+          inner join fmus f on f.id = o.fmu_id
+          left join operator_translations ot on ot.operator_id = o.operator_id and ot.locale = 'en'
+          where f.geojson is not null
+        ) as temp
+      ) as temp2
+      where inside_fmu = false and swapped_inside_fmu = true
+    SQL
+
+    results = ActiveRecord::Base.connection.execute(query).to_a
+    puts "#{results.count} results with swapped lng lat inside fmu"
+    puts "Observation ids: #{results.map { |r| r['id'] }.join(', ')}"
+    ActiveRecord::Base.transaction do
+      results.each do |res|
+        observation = Observation.find(res['id'])
+        lng = observation.lat
+        lat = observation.lng
+        puts "Updating lng/lat for observation #{observation.id}"
+        observation.update!(lng: lng, lat: lat)
+      end
+
+      raise ActiveRecord::Rollback unless for_real
+    end
+    puts "Done :)"
+  end
 end


### PR DESCRIPTION
Task to fix old observations lat/lng. The task will find all observations for which point with swapped lat/lng is closer to FMU centroid than saved one.