### PR TITLE
Backoffice: enhance displaying versions

### DIFF
--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -11,7 +11,7 @@ ActiveAdmin.register Operator, as: 'Producer' do
   actions :all
   permit_params :holding_id, :name, :fa_id, :operator_type, :country_id, :details, :concession, :is_active,
                 :logo, :delete_logo, :email, fmu_ids: [],
-                translations_attributes: [:id, :locale, :name, :details, :_destroy]
+                                             translations_attributes: [:id, :locale, :name, :details, :_destroy]
 
   member_action :activate, method: :put do
     resource.update(is_active: true)
@@ -222,6 +222,7 @@ ActiveAdmin.register Operator, as: 'Producer' do
       row :fa_id
       row :details
       row :country
+      row :concession
       row :logo do |o|
         link_to o.logo&.identifier, o.logo&.url
       end

--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -11,7 +11,7 @@ ActiveAdmin.register Operator, as: 'Producer' do
   actions :all
   permit_params :holding_id, :name, :fa_id, :operator_type, :country_id, :details, :concession, :is_active,
                 :logo, :delete_logo, :email, fmu_ids: [],
-                                             translations_attributes: [:id, :locale, :name, :details, :_destroy]
+                translations_attributes: [:id, :locale, :name, :details, :_destroy]
 
   member_action :activate, method: :put do
     resource.update(is_active: true)
@@ -26,21 +26,21 @@ ActiveAdmin.register Operator, as: 'Producer' do
   config.clear_action_items!
 
   action_item :toggle_active, only: [:show] do
-    if operator.is_active
-      link_to 'Deactivate', deactivate_admin_producer_path(operator),
-              method: :put, data: { confirm: "Are you sure you want to DEACTIVATE the producer #{operator.name}?" }
+    if resource.is_active
+      link_to 'Deactivate', deactivate_admin_producer_path(resource),
+              method: :put, data: { confirm: "Are you sure you want to DEACTIVATE the producer #{resource.name}?" }
     else
-      link_to 'Activate', activate_admin_producer_path(operator),
-              method: :put, data: { confirm: "Are you sure you want to ACTIVATE the producer #{operator.name}?" }
+      link_to 'Activate', activate_admin_producer_path(resource),
+              method: :put, data: { confirm: "Are you sure you want to ACTIVATE the producer #{resource.name}?" }
     end
   end
 
   action_item :edit, only: [:show] do
-    link_to 'Edit Producer', edit_admin_producer_path(operator)
+    link_to 'Edit Producer', edit_admin_producer_path(resource)
   end
 
   action_item :delete, only: [:show], if: -> { resource.can_hard_delete? } do
-    link_to 'Delete Producer', admin_producer_path(operator), method: :delete, data: { confirm: 'Are you sure you want to hard delete the producer?' }
+    link_to 'Delete Producer', admin_producer_path(resource), method: :delete, data: { confirm: 'Are you sure you want to hard delete the producer?' }
   end
 
   action_item :new, only: [:index] do
@@ -111,8 +111,9 @@ ActiveAdmin.register Operator, as: 'Producer' do
   scope :active
   scope :inactive
 
-  filter :country, as: :select,
-                   collection: -> { Country.joins(:operators).with_translations(I18n.locale).order('country_translations.name') }
+  filter :country,
+         as: :select,
+         collection: -> { Country.joins(:operators).with_translations(I18n.locale).order('country_translations.name') }
   filter :id,
          as: :select, label: 'Name',
          collection: -> { Operator.with_translations(I18n.locale).order('operator_translations.name').pluck(:name, :id) }
@@ -285,6 +286,7 @@ ActiveAdmin.register Operator, as: 'Producer' do
     def find_resource
       scoped_collection.unscope(:joins).with_translations.where(id: params[:id]).first!
     end
+
     def scoped_collection
       end_of_association_chain
         .with_translations(I18n.locale)

--- a/app/controllers/concerns/versionable.rb
+++ b/app/controllers/concerns/versionable.rb
@@ -2,19 +2,22 @@
 
 module Versionable
   def self.extended(base)
-    base.sidebar :versionate, partial: 'layouts/version', only: :show
-    base.controller do
-      def show
-        model = self.resource.class.base_class
-        var_name = self.resource.class.base_class.to_s.underscore
+    base.instance_eval do
+      sidebar :versionate, partial: 'layouts/version', only: :show
 
-        variable = model.includes(versions: :item).find(params[:id])
-        @versions = variable.versions
-        variable = variable.versions[params[:version].to_i].reify if params[:version]
-        # rubocop:disable Security/Eval
-        binding.eval("@#{var_name} = variable")
-        # rubocop:enable Security/Eval
-        show! #it seems to need this
+      controller do
+        def show
+          model = self.resource.class.base_class
+          var_name = self.resource.class.base_class.to_s.underscore
+
+          variable = model.includes(versions: :item).find(params[:id])
+          @versions = variable.versions
+          if params[:version]
+            variable = variable.versions[params[:version].to_i].reify rescue variable
+          end
+          instance_variable_set("@#{var_name}", variable)
+          show! #it seems to need this
+        end
       end
     end
   end

--- a/app/controllers/concerns/versionable.rb
+++ b/app/controllers/concerns/versionable.rb
@@ -8,7 +8,7 @@ module Versionable
       controller do
         def show
           model = resource.class.base_class
-          variable = model.includes(versions: :item).find(params[:id])
+          variable = current = model.includes(versions: :item).find(params[:id])
           @versions = variable.versions.where.not(event: 'create')
           @create_version = variable.versions.where(event: 'create').first
           begin
@@ -16,6 +16,8 @@ module Versionable
           rescue StandardError => e
             Sentry.capture_exception e
           end
+          # not sure why sometimes id is nil after reify
+          variable.id = current.id if variable.id.nil?
           instance_variable_set("@#{resource_instance_name}", variable)
           show! #it seems to need this
         end

--- a/app/controllers/concerns/versionable.rb
+++ b/app/controllers/concerns/versionable.rb
@@ -10,6 +10,7 @@ module Versionable
           model = resource.class.base_class
           variable = model.includes(versions: :item).find(params[:id])
           @versions = variable.versions.where.not(event: 'create')
+          @create_version = variable.versions.where(event: 'create').first
           begin
             variable = @versions[params[:version].to_i].reify if params[:version]
           rescue StandardError => e

--- a/app/controllers/concerns/versionable.rb
+++ b/app/controllers/concerns/versionable.rb
@@ -7,15 +7,15 @@ module Versionable
 
       controller do
         def show
-          model = self.resource.class.base_class
-          var_name = self.resource.class.base_class.to_s.underscore
-
+          model = resource.class.base_class
           variable = model.includes(versions: :item).find(params[:id])
           @versions = variable.versions
-          if params[:version]
-            variable = variable.versions[params[:version].to_i].reify rescue variable
+          begin
+            variable = variable.versions[params[:version].to_i].reify if params[:version]
+          rescue StandardError => e
+            Sentry.capture_exception e
           end
-          instance_variable_set("@#{var_name}", variable)
+          instance_variable_set("@#{resource_instance_name}", variable)
           show! #it seems to need this
         end
       end

--- a/app/controllers/concerns/versionable.rb
+++ b/app/controllers/concerns/versionable.rb
@@ -9,9 +9,9 @@ module Versionable
         def show
           model = resource.class.base_class
           variable = model.includes(versions: :item).find(params[:id])
-          @versions = variable.versions
+          @versions = variable.versions.where.not(event: 'create')
           begin
-            variable = variable.versions[params[:version].to_i].reify if params[:version]
+            variable = @versions[params[:version].to_i].reify if params[:version]
           rescue StandardError => e
             Sentry.capture_exception e
           end

--- a/app/views/layouts/_version.html.erb
+++ b/app/views/layouts/_version.html.erb
@@ -6,7 +6,7 @@
   <br>
   <b>User</b>: <%= User.find(@versions.last.whodunnit).email rescue '' %>
   <br>
-  <% if @versions.length.to_i > 1 %>
+  <% if @versions.length.to_i > 0 %>
     <% if params[:version].to_i > 0 || !params[:version] %>
       <%= link_to "Previous version", {:version => (params[:version] || @versions.length).to_i - 1}%>
       <br>
@@ -15,10 +15,10 @@
       <h3>This is <%= "#{params[:version]}"%> version</h3>
 
       <b>Modify at:</b>
-      <%= @versions[(params[:version].to_i - 1)].created_at %>
+      <%= @versions[params[:version].to_i].created_at %>
       <br>
       <b>User</b>:
-      <%= User.find(@versions[(params[:version].to_i - 1)].whodunnit).email rescue '' %>
+      <%= User.find(@versions[(params[:version].to_i)].whodunnit).email rescue '' %>
       <br>
 
       <%= link_to "Go to current version"%>

--- a/app/views/layouts/_version.html.erb
+++ b/app/views/layouts/_version.html.erb
@@ -1,10 +1,11 @@
 <% if !@versions.empty? %>
   <h3>Current Version: <%= @versions.length %></h3>
 
-  <b>Created At:</b>
-  <%= @versions.last.created_at%>
+  <% last_version = @versions.last %>
+
+  <b>Created At:</b> <%= last_version.created_at%>
   <br>
-  <b>User</b>: <%= User.find(@versions.last.whodunnit).email rescue '' %>
+  <b>User</b>: <%= User.find(last_version.whodunnit).email rescue '' %>
   <br>
   <% if @versions.length.to_i > 0 %>
     <% if params[:version].to_i > 0 || !params[:version] %>
@@ -12,18 +13,36 @@
       <br>
     <% end %>
     <% if params[:version] %>
-      <h3>This is <%= "#{params[:version]}"%> version</h3>
+      <% version = @versions[params[:version].to_i] %>
 
-      <b>Modify at:</b>
-      <%= @versions[params[:version].to_i].created_at %>
-      <br>
-      <b>User</b>:
-      <%= User.find(@versions[(params[:version].to_i)].whodunnit).email rescue '' %>
-      <br>
+      <% if version %>
+        <h3>This is <%= "#{params[:version]}"%> version</h3>
 
-      <%= link_to "Go to current version"%>
+        <% reify_version_info = version.previous %>
+        <!-- We are showing reify version which is object before changes -->
+        <% if reify_version_info %>
+          <b>Created at:</b> <%= reify_version_info.created_at %>
+          <br>
+          <b>User</b>: <%= User.find(reify_version_info.whodunnit).email rescue '' %>
+          <br>
+          <br>
+        <% end %>
+        <b>Modified at:</b> <%= version.created_at %>
+        <br>
+        <b>User</b>: <%= User.find(version.whodunnit).email rescue '' %>
+        <br>
+
+        <%= link_to "Go to current version"%>
+      <% end %>
     <% end %>
   <% end %>
+<% elsif @create_version %>
+  <h3>Current Version: 0</h3>
+
+  <b>Created At:</b>
+  <%= @create_version.created_at%>
+  <br>
+  <b>User</b>: <%= User.find(@create_version.whodunnit).email rescue '' %>
 <% else %>
   <p>This item does not have any registered version.</p>
 <% end %>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -297,10 +297,12 @@ ActiveAdmin.setup do |config|
 end
 
 require 'active_admin/filter_saver/controller'
+require 'active_admin/paper_trail/show_page_extension'
 
 ActiveAdmin.before_load do |app|
   # Add Filters Extensions
   ActiveAdmin::BaseController.include ActiveAdmin::FilterSaver::Controller
+  ActiveAdmin::Views::Pages::Show.prepend ActiveAdmin::PaperTrail::ShowPageExtension
 end
 
 # Modifies the display of the CSVs so that it shows on to download an English and a French versions.

--- a/lib/active_admin/paper_trail/show_page_extension.rb
+++ b/lib/active_admin/paper_trail/show_page_extension.rb
@@ -1,0 +1,17 @@
+module ActiveAdmin
+  module PaperTrail
+    module ShowPageExtension
+      def main_content
+        return version_error_message if params[:version] && resource.paper_trail.live?
+
+        super
+      end
+
+      def version_error_message
+        panel 'Error' do
+          'There is a problem with displaying this version.'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Display error message instead 500 page when paper trail reify did not work. We cannot run `reify` on `create` paper trail versions (according to documentation and also that returns just `nil`), that's why we only try to reify `update`, `destroy` events.

When object let's say Producer is created then `Versionate` sidebar will show that there are no other versions for this object. After every update there will be a new version, version = 0 is the first version.