### PR TITLE
Fix email sending to multiple recipients

### DIFF
--- a/app/services/mail_service.rb
+++ b/app/services/mail_service.rb
@@ -241,7 +241,7 @@ TXT
     body << text_fr.join("<br>")
 
     @from = ENV['CONTACT_EMAIL']
-    @to = operator.users.pluck(:email).join(', ')
+    @to = operator.users.pluck(:email)
     @body = body
     @subject = subject
     @content_type = "text/html"


### PR DESCRIPTION
If we want to send email to multiple recipients, then always use blind carbon copy (BCC).