### PR TITLE
Fix logo links in backoffice

### DIFF
--- a/app/admin/donor.rb
+++ b/app/admin/donor.rb
@@ -28,7 +28,7 @@ ActiveAdmin.register Donor do
     column :name
     column :website
     column :logo do |d|
-      link_to d.logo&.identifier, d.logo&.url
+      link_to d.logo&.identifier, d.logo&.url if d.logo&.url
     end
     column :priority
     column :description
@@ -58,7 +58,7 @@ ActiveAdmin.register Donor do
       row :name
       row :website
       row :logo do |d|
-        link_to d.logo&.identifier, d.logo&.url
+        link_to d.logo&.identifier, d.logo&.url if d.logo&.url
       end
       row :priority
       row :description

--- a/app/admin/observation_document.rb
+++ b/app/admin/observation_document.rb
@@ -41,7 +41,7 @@ ActiveAdmin.register ObservationDocument, as: 'Evidence' do
     column :observation, sortable: 'observation_id'
     column :name
     column :attachment do |o|
-      link_to o&.name, o.attachment&.url
+      link_to o&.name, o.attachment&.url if o.attachment&.url
     end
     column :user, sortable: 'users.name'
     column :created_at
@@ -87,7 +87,7 @@ ActiveAdmin.register ObservationDocument, as: 'Evidence' do
       row :id
       row :observation
       row :attachment do |o|
-        link_to o&.name, o.attachment&.url
+        link_to o&.name, o.attachment&.url if o.attachment&.url
       end
       row :user
       row :created_at

--- a/app/admin/observer.rb
+++ b/app/admin/observer.rb
@@ -48,7 +48,7 @@ ActiveAdmin.register Observer, as: 'Monitor' do
     # rubocop:enable Rails/OutputSafety
     column :observer_type, sortable: true
     column :logo do |o|
-      link_to o.logo&.identifier, o.logo&.url
+      link_to o.logo&.identifier, o.logo&.url if o.logo&.url
     end
     column :name, sortable: 'observer_translations.name'
     column :responsible_user

--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -224,7 +224,7 @@ ActiveAdmin.register Operator, as: 'Producer' do
       row :country
       row :concession
       row :logo do |o|
-        link_to o.logo&.identifier, o.logo&.url
+        link_to o.logo&.identifier, o.logo&.url if o.logo&.url
       end
       row :address
       row :website

--- a/app/admin/partner.rb
+++ b/app/admin/partner.rb
@@ -27,7 +27,7 @@ ActiveAdmin.register Partner do
     column :name
     column :website
     column :logo do |p|
-      link_to p.logo&.identifier, p.logo&.url
+      link_to p.logo&.identifier, p.logo&.url if p.logo&.url
     end
     column :priority
     column :description
@@ -57,7 +57,7 @@ ActiveAdmin.register Partner do
       row :name
       row :website
       row :logo do |p|
-        link_to p.logo&.identifier, p.logo&.url
+        link_to p.logo&.identifier, p.logo&.url if p.logo&.url
       end
       row :priority
       row :description


### PR DESCRIPTION
Instead of showing self links like this if there is no logo attached

![image](https://user-images.githubusercontent.com/1286444/215119562-eb7329fc-73f3-4e3a-8c74-96bb715b3030.png)

Show empty field

![image](https://user-images.githubusercontent.com/1286444/215119669-609d900e-a1ae-4caf-b986-cce39ea2c49d.png)
