### PR TITLE
set admin locale hot-fix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_admin_locale
-    I18n.locale = current_user&.locale || :en
+    I18n.locale = current_user&.locale&.presence || :en
   end
 
   protected


### PR DESCRIPTION
Some users have empty string not sure why, and that results with 500 error.