### PR TITLE
Chore/jsonapi upgrade to 0.9.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,11 +45,7 @@ gem 'rgeo'
 gem 'rgeo-geojson'
 
 # API
-#gem 'jsonapi-resources', '0.10.0'
-# TODO: version 0.9.12 has problems with including nested relationships, did not work on observation endpoint
-# leaving it as it is now. Better to bring up code coverage first as this gem is VERY unstable
-# I included another MONKEY PATCH to fix error with nil relationships (that is fixed by this commit https://github.com/cerebris/jsonapi-resources/commit/0280f70ae481ac18b7abc659a6580a82b71d4175)
-gem 'jsonapi-resources', '0.9.0'
+gem 'jsonapi-resources', '0.9.12'
 gem 'oj'
 gem 'oj_mimic_json'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jsonapi-resources (0.9.0)
+    jsonapi-resources (0.9.12)
       activerecord (>= 4.1)
       concurrent-ruby
       railties (>= 4.1)
@@ -589,7 +589,7 @@ DEPENDENCIES
   guard
   i18n_generators
   interactor (~> 3.0)
-  jsonapi-resources (= 0.9.0)
+  jsonapi-resources (= 0.9.12)
   jwt
   listen (~> 3.0.5)
   mini_magick

--- a/app/resources/concerns/operator_documentable.rb
+++ b/app/resources/concerns/operator_documentable.rb
@@ -23,10 +23,6 @@ module OperatorDocumentable
 
     privateable :document_visible?, [:start_date, :expire_date, :note, :reason, :response_date, :source_info, :uploaded_by, :created_at, :updated_at]
 
-    def custom_links(_)
-      { self: nil }
-    end
-
     def source_type
       return nil unless document_visible?
 

--- a/app/resources/v1/base_resource.rb
+++ b/app/resources/v1/base_resource.rb
@@ -1,9 +1,5 @@
 module V1
   class BaseResource < JSONAPI::Resource
     abstract
-
-    def custom_links(_)
-      { self: nil }
-    end
   end
 end

--- a/app/resources/v1/operator_resource.rb
+++ b/app/resources/v1/operator_resource.rb
@@ -116,7 +116,7 @@ module V1
     end
 
     def self.apply_includes(records, directives)
-      super.includes(:score_operator_document, :score_operator_observation)
+      super.includes(:score_operator_document, :score_operator_observation) if super.present?
     end
 
     def self.records(options = {})

--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -8,6 +8,7 @@ JSONAPI.configure do |config|
   config.resource_cache = Rails.cache
   config.always_include_to_one_linkage_data = false
   config.warn_on_missing_routes = false
+  config.default_exclude_links = :default
 
   # Metadata
   # Output record count in top level meta for find operation

--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -7,6 +7,7 @@ JSONAPI.configure do |config|
   config.maximum_page_size = 3000
   config.resource_cache = Rails.cache
   config.always_include_to_one_linkage_data = false
+  config.warn_on_missing_routes = false
 
   # Metadata
   # Output record count in top level meta for find operation
@@ -23,26 +24,53 @@ end
 module JSONAPI
   class ResourceSerializer
 
-    def link_object_to_many(source, relationship, include_linkage)
-      include_linkage = include_linkage | relationship.always_include_linkage_data
-      link_object_hash = {}
-      # MONKEY_PATCH to show the links only if there's linkage data
-      link_object_hash[:links] = {} if relationship.always_include_linkage_data
-      link_object_hash[:links][:self] = self_link(source, relationship) if relationship.always_include_linkage_data
-      link_object_hash[:links][:related] = related_link(source, relationship) if relationship.always_include_linkage_data
-      link_object_hash[:data] = to_many_linkage(source, relationship) if include_linkage
-      link_object_hash
-    end
+    def relationships_hash(source, fetchable_fields, include_directives = {})
+      if source.is_a?(CachedResourceFragment)
+        return cached_relationships_hash(source, include_directives)
+      end
 
-    def link_object_to_one(source, relationship, include_linkage)
-      include_linkage = include_linkage | @always_include_to_one_linkage_data | relationship.always_include_linkage_data
-      link_object_hash = {}
-      # MONKEY PATCH to show the links only if there's linkage data
-      link_object_hash[:links] = {} if relationship.always_include_linkage_data
-      link_object_hash[:links][:self] = self_link(source, relationship) if relationship.always_include_linkage_data
-      link_object_hash[:links][:related] = related_link(source, relationship) if relationship.always_include_linkage_data
-      link_object_hash[:data] = to_one_linkage(source, relationship) if include_linkage
-      link_object_hash
+      include_directives[:include_related] ||= {}
+
+      relationships = source.class._relationships.select{|k,v| fetchable_fields.include?(k) }
+      field_set = supplying_relationship_fields(source.class) & relationships.keys
+
+      relationships.each_with_object({}) do |(name, relationship), hash|
+        ia = include_directives[:include_related][name]
+        include_linkage = ia && ia[:include]
+        include_linked_children = ia && !ia[:include_related].empty?
+
+        if field_set.include?(name)
+          # MONKEY PATCH to fix included objects relationships
+          # from verions 0.9.7 there were no relationships for included objects
+          # so including nested relations stopped working for example for observation subcategory.category
+          hash[format_key(name)] = relationship_object(source, relationship, include_linkage)
+          # following commented lines were in the original code
+          # ro = relationship_object(source, relationship, include_linkage)
+          # hash[format_key(name)] = ro unless ro.blank?
+        end
+
+        # If the object has been serialized once it will be in the related objects list,
+        # but it's possible all children won't have been captured. So we must still go
+        # through the relationships.
+        if include_linkage || include_linked_children
+          resources = if source.preloaded_fragments.has_key?(format_key(name))
+            source.preloaded_fragments[format_key(name)].values
+          else
+            options = { filters: ia && ia[:include_filters] || {} }
+            [source.public_send(name, options)].flatten(1).compact
+          end
+          resources.each do |resource|
+            next if self_referential_and_already_in_source(resource)
+            id = resource.id
+            relationships_only = already_serialized?(relationship.type, id)
+            if include_linkage && !relationships_only
+              add_resource(resource, ia)
+            elsif include_linked_children || relationships_only
+              relationships_hash(resource, fetchable_fields, ia)
+            end
+          end
+        end
+      end
     end
   end
 
@@ -83,159 +111,6 @@ module JSONAPI
         records
       end
       # rubocop:enable Lint/UnderscorePrefixedVariableName
-
-      # READTHIS: MONKEY PATCH that adds this line  https://github.com/cerebris/jsonapi-resources/commit/0280f70ae481ac18b7abc659a6580a82b71d4175
-      # only this was changed in that method to fix nil relationships error
-      def preload_included_fragments(resources, records, serializer, options)
-        return if resources.empty?
-
-        res_ids = resources.keys
-
-        include_directives = options[:include_directives]
-        return unless include_directives
-
-        context = options[:context]
-
-        # For each association, including indirect associations, find the target record ids.
-        # Even if a target class doesn't have caching enabled, we still have to look up
-        # and match the target ids here, because we can't use ActiveRecord#includes.
-        #
-        # Note that `paths` returns partial paths before complete paths, so e.g. the partial
-        # fragments for posts.comments will exist before we start working with posts.comments.author
-        target_resources = {}
-        include_directives.paths.each do |path|
-          # If path is [:posts, :comments, :author], then...
-          pluck_attrs = [] # ...will be [posts.id, comments.id, authors.id, authors.updated_at]
-          pluck_attrs << self._model_class.arel_table[self._primary_key]
-
-          relation = records
-            .except(:limit, :offset, :order)
-            .where({ _primary_key => res_ids })
-
-          # These are updated as we iterate through the association path; afterwards they will
-          # refer to the final resource on the path, i.e. the actual resource to find in the cache.
-          # So e.g. if path is [:posts, :comments, :author], then after iteration...
-          parent_klass = nil # Comment
-          klass = self # Person
-          relationship = nil # JSONAPI::Relationship::ToOne for CommentResource.author
-          table = nil # people
-          assocs_path = [] # [ :posts, :approved_comments, :author ]
-          ar_hash = nil # { :posts => { :approved_comments => :author } }
-
-          # For each step on the path, figure out what the actual table name/alias in the join
-          # will be, and include the primary key of that table in our list of fields to select
-          non_polymorphic = true
-          path.each do |elem|
-            relationship = klass._relationships[elem]
-            if relationship.polymorphic
-              # Can't preload through a polymorphic belongs_to association, ResourceSerializer
-              # will just have to bypass the cache and load the real Resource.
-              non_polymorphic = false
-              break
-            end
-            assocs_path << relationship.relation_name(options).to_sym
-            # Converts [:a, :b, :c] to Rails-style { :a => { :b => :c }}
-            ar_hash = assocs_path.reverse.reduce{ |memo, step| { step => memo } }
-            # We can't just look up the table name from the resource class, because Arel could
-            # have used a table alias if the relation includes a self-reference.
-            join_source = relation.joins(ar_hash).arel.source.right.reverse.find do |arel_node|
-              arel_node.is_a?(Arel::Nodes::InnerJoin)
-            end
-            table = join_source.left
-            parent_klass = klass
-            klass = relationship.resource_klass
-            pluck_attrs << table[klass._primary_key]
-          end
-          next unless non_polymorphic
-
-          # Pre-fill empty hashes for each resource up to the end of the path.
-          # This allows us to later distinguish between a preload that returned nothing
-          # vs. a preload that never ran.
-          prefilling_resources = resources.values
-          path.each do |rel_name|
-            rel_name = serializer.key_formatter.format(rel_name)
-            prefilling_resources.map! do |res|
-              res.preloaded_fragments[rel_name] ||= {}
-              res.preloaded_fragments[rel_name].values
-            end
-            prefilling_resources.flatten!(1)
-          end
-
-          pluck_attrs << table[klass._cache_field] if klass.caching?
-          relation = relation.joins(ar_hash)
-          if relationship.is_a?(JSONAPI::Relationship::ToMany)
-            # Rails doesn't include order clauses in `joins`, so we have to add that manually here.
-            # FIXME Should find a better way to reflect on relationship ordering. :-(
-            relation = relation.order(parent_klass._model_class.new.send(assocs_path.last).arel.orders)
-          end
-
-          # [[post id, comment id, author id, author updated_at], ...]
-          id_rows = pluck_arel_attributes(relation.joins(ar_hash), *pluck_attrs)
-
-          target_resources[klass.name] ||= {}
-
-          if klass.caching?
-            sub_cache_ids = id_rows
-              .map{ |row| row.last(2) }
-              .reject{ |row| target_resources[klass.name].key?(row.first) }
-              .uniq
-            target_resources[klass.name].merge! CachedResourceFragment.fetch_fragments(
-              klass, serializer, context, sub_cache_ids
-            )
-          else
-            sub_res_ids = id_rows
-              .map(&:last)
-              .reject{ |id| target_resources[klass.name].key?(id) }
-              .uniq
-            found = klass.find({ klass._primary_key => sub_res_ids }, context: options[:context])
-            target_resources[klass.name].merge! found.map{ |r| [r.id, r] }.to_h
-          end
-
-          id_rows.each do |row|
-            res = resources[row.first]
-            path.each_with_index do |rel_name, index|
-              rel_name = serializer.key_formatter.format(rel_name)
-              rel_id = row[index+1]
-              assoc_rels = res.preloaded_fragments[rel_name]
-              if index == path.length - 1
-                association_res = target_resources[klass.name].fetch(rel_id, nil)
-                assoc_rels[rel_id] = association_res if association_res
-              else
-                res = assoc_rels[rel_id]
-              end
-            end
-          end
-        end
-      end
-    end
-  end
-
-  module ActsAsResourceController
-    def render_results(operation_results)
-      response_doc = create_response_document(operation_results)
-      content = response_doc.contents
-
-      render_options = {}
-      if operation_results.has_errors?
-        render_options[:json] = content
-      else
-        # Bypasing ActiveSupport allows us to use CompiledJson objects for cached response fragments
-        render_options[:body] = JSON.generate(content)
-      end
-
-      # MONKEY PATCH : To allow the gem to work without links
-      if content[:data].is_a?(Hash) && content.dig(:data, :links, :self).present?
-        render_options[:location] = content[:data]["links"][:self] if
-        response_doc.status == :created && content[:data].class != Array
-
-      end
-
-      # For whatever reason, `render` ignores :status and :content_type when :body is set.
-      # But, we can just set those values directly in the Response object instead.
-      response.status = response_doc.status
-      response.headers['Content-Type'] = JSONAPI::MEDIA_TYPE
-
-      render(render_options)
     end
   end
 end

--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -32,7 +32,7 @@ module JSONAPI
 
       include_directives[:include_related] ||= {}
 
-      relationships = source.class._relationships.select{|k,v| fetchable_fields.include?(k) }
+      relationships = source.class._relationships.select{ |k,v| fetchable_fields.include?(k) }
       field_set = supplying_relationship_fields(source.class) & relationships.keys
 
       relationships.each_with_object({}) do |(name, relationship), hash|
@@ -54,14 +54,15 @@ module JSONAPI
         # but it's possible all children won't have been captured. So we must still go
         # through the relationships.
         if include_linkage || include_linked_children
-          resources = if source.preloaded_fragments.has_key?(format_key(name))
-            source.preloaded_fragments[format_key(name)].values
-          else
-            options = { filters: ia && ia[:include_filters] || {} }
-            [source.public_send(name, options)].flatten(1).compact
-          end
+          resources = if source.preloaded_fragments.key?(format_key(name))
+                        source.preloaded_fragments[format_key(name)].values
+                      else
+                        options = { filters: ia && ia[:include_filters] || {} }
+                        [source.public_send(name, options)].flatten(1).compact
+                      end
           resources.each do |resource|
             next if self_referential_and_already_in_source(resource)
+
             id = resource.id
             relationships_only = already_serialized?(relationship.type, id)
             if include_linkage && !relationships_only

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -11,7 +11,7 @@
 
 FactoryBot.define do
   factory :category do
-    sequence(:name) { |n| "#{n} Category #{Faker::Address.country}" }
-    category_type { rand(0..1) }
+    name { "Category name" }
+    category_type { "operator" }
   end
 end

--- a/spec/factories/observations.rb
+++ b/spec/factories/observations.rb
@@ -61,6 +61,7 @@ FactoryBot.define do
     species { build_list(:species, 1, name: "Species #{Faker::Lorem.sentence}") }
     user { build(:admin) }
     observation_type { 'government' }
+    validation_status { 'Published (no comments)' }
     is_active { true }
     publication_date { DateTime.now.yesterday.to_date }
     lng { 12.2222 }
@@ -71,6 +72,7 @@ FactoryBot.define do
     country
     subcategory
     observation_report
+    law
     user { build(:admin) }
     severity { build(:severity, subcategory: subcategory) }
     operator { create(:operator, country: country) }

--- a/spec/factories/operators.rb
+++ b/spec/factories/operators.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
     country
     sequence(:name) { |n| "Operator #{n}" }
     logo { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'files', 'image.png')) }
-    operator_type { Operator::TYPES.sample }
+    operator_type { 'Logging company' }
     is_active { true }
 
     trait :with_sawmills do

--- a/spec/factories/subcategories.rb
+++ b/spec/factories/subcategories.rb
@@ -14,8 +14,8 @@
 
 FactoryBot.define do
   factory :subcategory, class: 'Subcategory' do
-    sequence(:name) { |n| "Subcategory#{n}" }
-    subcategory_type { rand(0..1) }
+    name { "Subcategory name" }
+    subcategory_type { "operator" }
 
     after(:build) do |random_subcategory|
       random_subcategory.category ||= FactoryBot.create(:category)


### PR DESCRIPTION
Upgrading jsonapi resources to newest 0.9 version which has Rails 6.1 support.

Note: I tried both master and 0.10 branch of jsonapi resources and always had different issues. I'm tired of this library, but creating API from scratch using for example jsonapi serializer is a big task at this point.

I tested that with both frontend apps using automated Cypress tests and all looked good. Will push this to staging soon to have it there for a while.