### PR TITLE
Hide old observations moved to cronjob

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -29,43 +29,8 @@ ActiveAdmin.register_page "Dashboard" do
     end
   end
 
-  page_action :hide_old_observations, method: :post do
-    authorize! :hide_old_observations
-    if system "rake observations:hide"
-      redirect_to admin_dashboard_path, notice: t("active_admin.dashboard_page.hide_observations.hidden")
-    else
-      redirect_to admin_dashboard_path, notice: t("active_admin.dashboard_page.hide_observations.error")
-    end
-  end
-
   content title: proc { I18n.t("active_admin.dashboard") } do
     if current_user.user_permission.user_role == "admin"
-      obs_count = Observation.where("publication_date < ? and hidden = false", Time.zone.today - 5.years).count
-
-      unless obs_count.zero?
-        columns do
-          button_to t("active_admin.dashboard_page.hide_observations.hide_observations"),
-            "/admin/dashboard/hide_old_observations",
-            method: :post,
-            data:
-            {
-              disable_with: t("active_admin.dashboard_page.hide_observations.disable_with"),
-              confirm: t("active_admin.dashboard_page.hide_observations.confirm")
-            },
-            class: "deploy-button"
-        end
-        panel t("active_admin.dashboard_page.old_observations.old_observations", count: obs_count) do
-          table_for Observation.includes(:subcategory, :operator, country: :translations).to_be_hidden.order("observation_reports.publication_date desc").limit(20) do
-            column("ID") { |obs| link_to obs.id, admin_observation_path(obs.id) }
-            column(t("active_admin.dashboard_page.columns.publication_date")) { |obs| obs.observation_report&.publication_date }
-            column(t("active_admin.dashboard_page.columns.country")) { |obs| obs.country }
-            column(t("active_admin.dashboard_page.columns.subcategory")) { |obs| obs.subcategory }
-            column(t("active_admin.dashboard_page.columns.operator")) { |obs| obs.operator }
-            column(t("active_admin.dashboard_page.columns.date")) { |obs| obs.publication_date.strftime("%A, %d/%b/%Y") }
-          end
-        end
-      end
-
       if Rails.env.staging? || Rails.env.development?
         columns do
           column do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,15 +276,6 @@ en:
         error: 'Error while deploying IM Backoffice'
         disable_with: 'Deploying IM Backoffice...'
         confirm: 'Are you sure you want to deploy the IM BACKOFFICE?'
-      hide_observations:
-        hide_observations: 'Hide old observations'
-        hidden: 'Old observations hidden'
-        error: 'Error while hiding old observations'
-        disable_with: 'Hiding old observations...'
-        confirm: 'Are you sure you want to hide old observations?'
-      old_observations:
-        old_observations: "Old observations (%{count})"
-        publication_date: 'Publication date'
       new_producers:
         new_producers: 'New Producers'
         no_country: 'No country'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -286,14 +286,6 @@ fr:
         error: 'Erreur lors du déploiement de IM Backoffice'
         disable_with: 'Déploiement du backoffice IM...'
         confirm: 'Êtes-vous sûr de vouloir déployer le BACKOFFICE IM?'
-      hide_observations:
-        hide_observations: 'Cacher les vieilles observations'
-        hidden: 'Vielles observations cachées'
-        error: "Erreur lors du masquage des vielles observations"
-        disable_with: 'Cacher de vieilles observations...'
-        confirm: 'Voulez-vous vraiment masquer les vielles observations?'
-      old_observations:
-        old_observations: "Observations vieilles (%{count})"
       new_producers:
         new_producers: 'Nouveaux producteurs'
         no_country: 'Aucun pays'

--- a/lib/tasks/observations.rake
+++ b/lib/tasks/observations.rake
@@ -1,7 +1,7 @@
 namespace :observations do
   desc "Hide observations older than 5 year"
   task hide: :environment do
-    Observation.to_be_hidden.update_all(hidden: true, updated_at: DateTime.now)
+    Observation.to_be_hidden.update_all(hidden: true, is_active: false, updated_at: DateTime.now)
   end
 
   desc "Recalculate observation scores for operators"


### PR DESCRIPTION
We don't need this on the dashboard anymore.