### PR TITLE
Fix sending newsletter

### DIFF
--- a/app/mailers/operator_mailer.rb
+++ b/app/mailers/operator_mailer.rb
@@ -38,7 +38,11 @@ class OperatorMailer < ApplicationMailer
   # In the future this should be refactored:
   # 1. To send it in the language of the user and use I18n
   # 2. To send it using the html template
-  def quarterly_newsletter(operator)
+  def quarterly_newsletter(operator, user)
+    return if operator.users.filter_actives.empty?
+    return if user.nil?
+    raise "User is not eligible to receive this newsletter" unless operator.users.filter_actives.include?(user)
+
     current_score = operator.score_operator_document
     last_score = operator.score_operator_documents.at_date(Time.zone.today - 3.months).order(:date).last
     expiring_docs = operator.operator_documents.to_expire(Time.zone.today + 3.months)
@@ -86,7 +90,7 @@ class OperatorMailer < ApplicationMailer
     body << "<br>----------------------------------------------------<br>"
     body << text_fr.join("<br>")
 
-    mail bcc: operator.users.pluck(:email).join(", "),
+    mail to: user.email,
       subject: subject,
       body: body,
       content_type: "text/html"

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -91,6 +91,8 @@ class Operator < ApplicationRecord
   scope :active, -> { where(is_active: true) }
   scope :inactive, -> { where(is_active: false) }
   scope :fa_operator, -> { where("fa_id <> ''") }
+  scope :approved, -> { where(approved: true) }
+  scope :newsletter_eligible, -> { active.approved.fa_operator }
 
   scope :filter_by_country_ids, ->(country_ids) { where(country_id: country_ids.split(",")) }
 

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -69,8 +69,14 @@ namespace :scheduler do
     Rails.logger.info "Going to send quarterly newsletters: #{Time.zone.now.strftime("%d/%m/%Y %H:%M")}"
     failed = false
     time = Benchmark.ms do
-      Operator.active.fa_operator.find_each do |operator|
-        operator.users.filter_actives.each do |user|
+      operators = Operator.newsletter_eligible
+      operators = operators.where(id: ENV["OPERATOR_IDS"].split(",")) if ENV["OPERATOR_IDS"].present?
+
+      operators.find_each do |operator|
+        users = operator.users.filter_actives
+        users = users.where(id: ENV["USER_IDS"].split(",")) if ENV["USER_IDS"].present?
+
+        users.each do |user|
           OperatorMailer.quarterly_newsletter(operator, user).deliver_now
         end
       rescue => e

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -70,7 +70,9 @@ namespace :scheduler do
     failed = false
     time = Benchmark.ms do
       Operator.active.fa_operator.find_each do |operator|
-        OperatorMailer.quarterly_newsletter(operator).deliver_now
+        operator.users.filter_actives.each do |user|
+          OperatorMailer.quarterly_newsletter(operator, user).deliver_now
+        end
       rescue => e
         failed = true
         Sentry.capture_exception(e, extra: {"operator_id" => operator.id})

--- a/spec/mailers/operator_mailer_spec.rb
+++ b/spec/mailers/operator_mailer_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe OperatorMailer, type: :mailer do
 
   describe "quarterly_newsletter" do
     let(:operator) { create(:operator) }
-    let(:mail) { OperatorMailer.quarterly_newsletter(operator) }
+    let(:user) { create(:operator_user, operator: operator) }
+    let(:mail) { OperatorMailer.quarterly_newsletter(operator, user) }
 
     it "renders the headers" do
       expect(mail.subject).to eq("Your quarterly OTP report / Votre rapport trimestriel sur l'OTP")
-      expect(mail.to).to eq(nil)
-      expect(mail.bcc).to eq(operator.users.pluck(:email))
+      expect(mail.to).to eq([user.email])
     end
 
     it "renders the body" do

--- a/spec/mailers/previews/operator_mailer_preview.rb
+++ b/spec/mailers/previews/operator_mailer_preview.rb
@@ -4,13 +4,13 @@ class OperatorMailerPreview < ActionMailer::Preview
   end
 
   def quarterly_newsletter
-    OperatorMailer.quarterly_newsletter operator
+    OperatorMailer.quarterly_newsletter operator, operator.users.filter_actives.first
   end
 
   private
 
   def documents
-    OperatorDocument.where(operator_id: operator_id).to_expire(Time.zone.today)
+    OperatorDocument.where(operator_id: operator_id).to_expire(1.month.from_now)
   end
 
   def operator
@@ -18,6 +18,6 @@ class OperatorMailerPreview < ActionMailer::Preview
   end
 
   def operator_id
-    OperatorDocument.to_expire(Time.zone.today).pluck(:operator_id).take(1).first
+    OperatorDocument.to_expire(1.month.from_now).pluck(:operator_id).take(1).first
   end
 end


### PR DESCRIPTION
The newsletter code will be eventually refactored, so I focused on just fixing it. We cannot use `bcc` without setting `to` when using SendGrid. I also read that BCC might not be great in terms of deliverability, that's why I decided to just send emails individually. We could do that with one API call with SendGrid API using `personalizations` object, but I preferred to use a method acceptable by any ActionMailer client.