### PR TITLE
Feature/observation publication date cleanup

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -111,7 +111,7 @@ ActiveAdmin.register_page "Dashboard" do
             column(t("active_admin.dashboard_page.columns.country")) { |obs| obs.country }
             column(t("active_admin.dashboard_page.columns.subcategory")) { |obs| obs.subcategory }
             column(t("active_admin.dashboard_page.columns.operator")) { |obs| obs.operator }
-            column(t("active_admin.dashboard_page.columns.date")) { |obs| obs.publication_date.strftime("%A, %d/%b/%Y") }
+            column(t("active_admin.dashboard_page.columns.date")) { |obs| obs&.publication_date&.strftime("%A, %d/%b/%Y") }
           end
         end
       end

--- a/app/admin/observation.rb
+++ b/app/admin/observation.rb
@@ -25,6 +25,7 @@ ActiveAdmin.register Observation do
 
   config.order_clause
   config.per_page = per_page
+  config.sort_order = "updated_at_desc"
 
   before_action only: :index do
     if per_page.include? params[:per_page]
@@ -568,7 +569,7 @@ ActiveAdmin.register Observation do
       f.input :publication_date,
         as: :date_time_picker,
         picker_options: {timepicker: false, format: "Y-m-d"},
-        **visibility
+        input_html: {disabled: true}
       f.input :pv, **visibility
       f.input :location_accuracy, as: :select, **visibility
       f.input :lat, **visibility

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -131,13 +131,13 @@ class Observation < ApplicationRecord
   validate :evidence_presented_in_the_report
   validate :status_changes, if: -> { user_type.present? }
 
-  validates :publication_date, presence: true
   validates :validation_status, presence: true
   validates :observation_type, presence: true
 
   before_save :set_active_status
   before_save :check_is_physical_place
   before_save :set_centroid
+  before_save :set_publication_date, if: :validation_status_changed?
   before_create :set_default_observer
   before_create :set_responsible_admin
 
@@ -235,6 +235,10 @@ class Observation < ApplicationRecord
     self.lat = nil
     self.lng = nil
     self.fmu = nil
+  end
+
+  def set_publication_date
+    self.publication_date = Time.zone.now if published?
   end
 
   def set_centroid

--- a/app/resources/v1/observation_resource.rb
+++ b/app/resources/v1/observation_resource.rb
@@ -5,7 +5,7 @@ module V1
     include CacheableByLocale
     # caching
 
-    attributes :observation_type, :publication_date, :report_publication_date, :pv, :is_active,
+    attributes :observation_type, :publication_date, :pv, :is_active,
       :details, :evidence_type, :evidence_on_report, :concern_opinion,
       :litigation_status, :location_accuracy, :lat, :lng, :country_id,
       :fmu_id, :location_information, :subcategory_id, :severity_id,
@@ -97,10 +97,6 @@ module V1
       end
 
       false
-    end
-
-    def report_publication_date
-      @model.observation_report&.publication_date
     end
 
     def validation_status_id

--- a/spec/factories/observations.rb
+++ b/spec/factories/observations.rb
@@ -81,7 +81,6 @@ FactoryBot.define do
     species { build_list(:species, 1, name: "Species #{Faker::Lorem.sentence}") }
     is_active { true }
     validation_status { "Published (no comments)" }
-    publication_date { DateTime.now.to_date }
     lng { 12.2222 }
     lat { 12.3333 }
 

--- a/spec/integration/v1/observations_spec.rb
+++ b/spec/integration/v1/observations_spec.rb
@@ -73,7 +73,7 @@ module V1
       describe "For admin user" do
         it "Returns error object when the observation cannot be created by admin" do
           post("/observations",
-            params: jsonapi_params("observations", nil, {"country-id": "", "observation-type": "operator", "publication-date": DateTime.now}),
+            params: jsonapi_params("observations", nil, {"country-id": "", "observation-type": "operator"}),
             headers: admin_headers)
 
           expect(parsed_body).to eq(jsonapi_errors(422, 100, {relationships_country: ["must exist"]}))

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -207,6 +207,17 @@ RSpec.describe Observation, type: :model do
       end
     end
 
+    describe "#set_publication_date" do
+      context "when publishing an observation" do
+        it "set publication_date with the current date" do
+          observation = create(:observation, validation_status: "Created")
+          expect(observation.publication_date).to eql nil
+          observation.update!(validation_status: "Published (no comments)")
+          expect(observation.publication_date.to_date).to eql Date.current
+        end
+      end
+    end
+
     describe "#set_active_status" do
       context "when validation_status is Approved" do
         it "set is_active to true" do


### PR DESCRIPTION
Observation publication date is only information, should be only updated if observation is published in any case, not only through API. Cannot be updated in the form.