### PR TITLE
Fix user registration missing locale param

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,7 +379,7 @@ GEM
       optimist (~> 3.0)
     pg (1.5.3)
     public_suffix (5.0.1)
-    puma (6.3.0)
+    puma (6.3.1)
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.7)

--- a/app/controllers/v1/registrations_controller.rb
+++ b/app/controllers/v1/registrations_controller.rb
@@ -21,7 +21,7 @@ module V1
     private
 
     def user_params
-      params.require(:user).permit(:name, :email, :password, :password_confirmation,
+      params.require(:user).permit(:name, :email, :locale, :password, :password_confirmation,
         :permissions_request, :country_id, :observer_id, :operator_id).tap do |user_params|
         user_params[:permissions_request] = params[:user][:permissions_request].downcase if params[:user][:permissions_request].present?
       end

--- a/spec/integration/v1/user_registration_spec.rb
+++ b/spec/integration/v1/user_registration_spec.rb
@@ -20,6 +20,7 @@ module V1
         email: "test@gmail.com",
         password: "password",
         password_confirmation: "password",
+        locale: "en",
         permissions_request: "government",
         name: "Test user new"
       }
@@ -48,6 +49,7 @@ module V1
         }.to have_enqueued_mail(SystemMailer, :user_created)
 
         expect(parsed_body).to eq({messages: [{status: 201, title: "User successfully registered!"}]})
+        expect(User.find_by(email: "test@gmail.com").locale).to eq("en")
         expect(status).to eq(201)
       end
 


### PR DESCRIPTION
Fix user registration endpoint to allow `locale` param.