### PR TITLE
fix(Admin): Change filter by name on producers page

### DIFF
--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -134,7 +134,7 @@ ActiveAdmin.register Operator, as: "Producer" do
   dependent_filters do
     {
       country_id: {
-        name_eq: Operator.pluck(:country_id, :name)
+        id: Operator.pluck(:country_id, :id)
       }
     }
   end

--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -124,9 +124,9 @@ ActiveAdmin.register Operator, as: "Producer" do
   filter :country,
     as: :select,
     collection: -> { Country.joins(:operators).with_translations(I18n.locale).order("country_translations.name") }
-  filter :name_eq,
+  filter :id,
     as: :select, label: -> { I18n.t("activerecord.attributes.operator.name") },
-    collection: -> { Operator.order(:name).pluck(:name) }
+    collection: -> { Operator.order(:name).pluck(:name, :id) }
   filter :concession, as: :select
   filter :fa_id_present, as: :boolean, label: proc { I18n.t("active_admin.operator_page.with_fa_uuid") }
   filter :fmus_id_null, as: :boolean, label: proc { I18n.t("active_admin.operator_page.fmus_id_null") }


### PR DESCRIPTION
The filter by name on the producers page now uses the id of the producer selected.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The search was done by name (which failed when the name had special characters).

Issue Number: #183458551


## What is the new behavior?
It now uses the selected producer's id.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
