### PR TITLE
Feature/User can manage other observers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,3 +50,6 @@ Rails/SkipsModelValidations:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
+Rails/HasAndBelongsToMany:
+  Enabled: false
+

--- a/app/admin/observer.rb
+++ b/app/admin/observer.rb
@@ -17,7 +17,8 @@ ActiveAdmin.register Observer, as: "Monitor" do
   end
 
   permit_params :observer_type, :is_active, :logo, :organization_type, :delete_logo,
-    :responsible_user_id, :responsible_admin_id, translations_attributes: [:id, :locale, :name, :_destroy], country_ids: []
+    :responsible_user_id, :responsible_admin_id,
+    translations_attributes: [:id, :locale, :name, :_destroy], country_ids: []
 
   csv do
     column :is_active

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -6,45 +6,40 @@ $(document).ready(function() {
 })
 
 function updateFields() {
-  var userRole = $('#user_user_permission_attributes_user_role').val();
-  var observerInput = $('#user_observer_id');
-  var operatorInput = $('#user_operator_id');
-  var holdingInput = $('#user_holding_id');
+  const userRole = $('#user_user_permission_attributes_user_role').val();
+  const observerInput = $('#user_observer_id');
+  const managedObserversInput = $('#user_managed_observer_ids');
+  const operatorInput = $('#user_operator_id');
+  const holdingInput = $('#user_holding_id');
+
+  const showInput = (input) => {
+    input.prop('disabled', false);
+    input.parent().show();
+  };
+  const hideInput = (input) => {
+    input.prop('disabled', true);
+    input.parent().hide();
+  };
+
+  hideInput(operatorInput);
+  hideInput(holdingInput);
+  hideInput(observerInput);
+  hideInput(managedObserversInput);
 
   switch (userRole) {
     case 'holding':
-      holdingInput.prop('disabled', false);
-      holdingInput.parent().show();
-      observerInput.prop('disabled', true);
-      observerInput.parent().hide();
-      operatorInput.prop('disabled', true);
-      operatorInput.parent().hide();
+      showInput(holdingInput);
       break;
     case 'ngo':
     case 'ngo_manager':
-      holdingInput.prop('disabled', true);
-      holdingInput.parent().hide();
-      observerInput.prop('disabled', false);
-      observerInput.parent().show();
-      operatorInput.prop('disabled', true);
-      operatorInput.parent().hide();
+      showInput(observerInput);
+      showInput(managedObserversInput);
       break;
     case 'operator':
-      holdingInput.prop('disabled', true);
-      holdingInput.parent().hide();
-      observerInput.prop('disabled', true);
-      observerInput.parent().hide();
-      operatorInput.prop('disabled', false);
-      operatorInput.parent().show();
+      showInput(operatorInput);
       break;
     case 'admin':
-    case 'user':
-      observerInput.prop('disabled', true);
-      observerInput.parent().hide();
-      operatorInput.prop('disabled', true);
-      operatorInput.parent().hide();
-      holdingInput.prop('disabled', true);
-      holdingInput.parent().hide();
+      showInput(managedObserversInput);
       break;
   }
 }

--- a/app/controllers/v1/imports_controller.rb
+++ b/app/controllers/v1/imports_controller.rb
@@ -5,7 +5,7 @@ module V1
     authorize_resource :file_data_import
 
     def create
-      importer.import(user_id_params)
+      importer.import(user_id_params.merge(importer_params))
 
       render json: importer.results
     end
@@ -17,11 +17,15 @@ module V1
     end
 
     def import_params
-      params.fetch(:import).permit(:importer_type, :file)
+      params.fetch(:import).permit(:importer_type, :file, :importer_params)
     end
 
     def importer
       @importer ||= FileDataImport::BaseImporter.build(import_params[:importer_type], import_params[:file])
+    end
+
+    def importer_params
+      JSON.parse(import_params[:importer_params] || {}).symbolize_keys
     end
 
     def user_id_params

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -20,7 +20,7 @@ module V1
 
     def current
       user = User.find(context[:current_user].id)
-      include_resources = %w[user_permission observer operator country observer.country]
+      include_resources = %w[user_permission observer managed_observers operator country observer.country]
       render json: JSONAPI::ResourceSerializer.new(
         UserResource,
         include: include_resources

--- a/app/importers/observations_importer.rb
+++ b/app/importers/observations_importer.rb
@@ -6,6 +6,7 @@ class ObservationsImporter < FileDataImport::BaseImporter
     observation_type publication_date pv is_active location_accuracy
     lat lng fmu_id evidence_type location_information actions_taken
     evidence_on_report validation_status is_physical_place user_id
+    observer_ids
   ].freeze
 
   PERMITTED_TRANSLATES = %i[

--- a/app/models/concerns/roleable.rb
+++ b/app/models/concerns/roleable.rb
@@ -17,8 +17,16 @@ module Roleable
       user_permission.user_role.in?("admin")
     end
 
+    def holding?
+      user_permission.user_role.in?("holding")
+    end
+
     def ngo?
       user_permission.user_role.in?("ngo")
+    end
+
+    def ngo_manager?
+      user_permission.user_role.in?("ngo_manager")
     end
 
     def operator?

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -28,9 +28,7 @@ class Country < ApplicationRecord
 
   has_many :users, inverse_of: :country
   has_many :observations, inverse_of: :country
-  # rubocop:disable Rails/HasAndBelongsToMany
   has_and_belongs_to_many :observers
-  # rubocop:enable Rails/HasAndBelongsToMany
   has_many :governments, inverse_of: :country
   has_many :operators, inverse_of: :country
   has_many :fmus, inverse_of: :country

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -131,6 +131,7 @@ class Observation < ApplicationRecord
   validate :evidence_presented_in_the_report
   validate :status_changes, if: -> { user_type.present? }
 
+  validates :observers, presence: true
   validates :validation_status, presence: true
   validates :observation_type, presence: true
 
@@ -159,13 +160,13 @@ class Observation < ApplicationRecord
 
   # TODO Check if we can change the joins with a with_translations(I18n.locale)
   scope :active, -> { includes(:translations).where(is_active: true).visible }
-  scope :own_with_inactive, ->(observer) {
+  scope :own_with_inactive, ->(observer_id) {
     joins(
       <<~SQL
         INNER JOIN "observer_observations" ON "observer_observations"."observation_id" = "observations"."id"
         INNER JOIN "observers" as "all_observers" ON "observer_observations"."observer_id" = "all_observers"."id"
       SQL
-    ).where(all_observers: {id: observer})
+    ).where(all_observers: {id: observer_id})
   }
 
   scope :by_category, ->(category_id) { joins(:subcategory).where(subcategories: {category_id: category_id}) }

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -147,12 +147,11 @@ class Observation < ApplicationRecord
   after_create :update_operator_scores, if: :is_active?
   after_create :update_reports_observers
   after_update :update_operator_scores, if: -> { saved_change_to_publication_date? || saved_change_to_severity_id? || saved_change_to_is_active? || saved_change_to_operator_id? || saved_change_to_fmu_id? }
-  after_update :update_reports_observers, if: :saved_change_to_observation_report_id?
 
   after_destroy :update_operator_scores
   after_destroy :update_fmu_geojson
-  after_destroy :update_reports_observers
 
+  after_save :update_reports_observers, if: :saved_change_to_observation_report_id?
   after_save :create_history, if: :saved_changes?
 
   after_save :remove_documents, if: -> { evidence_type == "Evidence presented in the report" }

--- a/app/models/observation_report.rb
+++ b/app/models/observation_report.rb
@@ -32,4 +32,8 @@ class ObservationReport < ApplicationRecord
   after_restore :move_attachment_to_public_directory
 
   scope :bigger_date, ->(date) { where("observation_reports.created_at <= ?", date + 1.day) }
+
+  def update_observers
+    self.observer_ids = observations.map(&:observers).map(&:ids).flatten.uniq if observations.any?
+  end
 end

--- a/app/models/observation_report.rb
+++ b/app/models/observation_report.rb
@@ -34,6 +34,6 @@ class ObservationReport < ApplicationRecord
   scope :bigger_date, ->(date) { where("observation_reports.created_at <= ?", date + 1.day) }
 
   def update_observers
-    self.observer_ids = observations.map(&:observers).map(&:ids).flatten.uniq if observations.any?
+    self.observer_ids = observations.joins(:observers).distinct.pluck("observers.id") if observations.any?
   end
 end

--- a/app/models/observer.rb
+++ b/app/models/observer.rb
@@ -37,9 +37,7 @@ class Observer < ApplicationRecord
   mount_base64_uploader :logo, LogoUploader
   attr_accessor :delete_logo
 
-  # rubocop:disable Rails/HasAndBelongsToMany
   has_and_belongs_to_many :countries
-  # rubocop:enable Rails/HasAndBelongsToMany
 
   has_many :observer_observations, dependent: :restrict_with_error
   has_many :observations, through: :observer_observations
@@ -48,6 +46,8 @@ class Observer < ApplicationRecord
   has_many :observation_reports, through: :observation_report_observers
 
   has_many :users, inverse_of: :observer
+  has_and_belongs_to_many :managers, join_table: "observer_managers", class_name: "User", dependent: :destroy
+
   belongs_to :responsible_user, class_name: "User", optional: true
   belongs_to :responsible_admin, class_name: "User", optional: true
 

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -23,6 +23,7 @@
 #  country_operators :integer
 #  name              :string
 #  details           :string
+#  slug              :string
 #
 
 class Operator < ApplicationRecord

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: pages
+#
+#  id                     :bigint           not null, primary key
+#  slug                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  available_in_languages :string           is an Array
+#  title                  :string
+#  body                   :text
+#
 class Page < ApplicationRecord
   include Translatable
   translates :title, :body, touch: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,8 @@ class User < ApplicationRecord
   has_many :observation_reports, inverse_of: :user
   has_many :operator_document_annexes, inverse_of: :user
 
+  has_and_belongs_to_many :managed_observers, join_table: "observer_managers", class_name: "Observer", dependent: :destroy
+
   belongs_to :observer, optional: true
   belongs_to :operator, optional: true
   belongs_to :holding, optional: true
@@ -100,6 +102,10 @@ class User < ApplicationRecord
     return false unless self&.user_permission&.user_role == "holding"
 
     Operator.find_by(id: operator_id)&.holding_id == holding_id
+  end
+
+  def all_managed_observer_ids
+    [observer_id, *managed_observer_ids].compact.uniq
   end
 
   def operator_ids

--- a/app/models/user_observer.rb
+++ b/app/models/user_observer.rb
@@ -1,4 +1,0 @@
-class UserObserver < ApplicationRecord
-  belongs_to :user
-  belongs_to :observer
-end

--- a/app/models/user_observer.rb
+++ b/app/models/user_observer.rb
@@ -1,0 +1,4 @@
+class UserObserver < ApplicationRecord
+  belongs_to :user
+  belongs_to :observer
+end

--- a/app/models/user_permission.rb
+++ b/app/models/user_permission.rb
@@ -49,9 +49,9 @@ class UserPermission < ApplicationRecord
        sawmill: {create: {}, ud: {operator: {holding_id: user.holding_id}}}}
     when "ngo"
       {user: {manage: {id: user.id}},
-       observation: {manage: {observers: {id: user.observer_id}}, create: {}},
-       observation_report: {update: {observers: {id: user.observer_id}}, create: {}},
-       observation_documents: {ud: {observation: {is_active: false, observers: {id: user.observer_id}}}, create: {}},
+       observation: {manage: {observers: {id: user.all_managed_observer_ids}}, create: {}},
+       observation_report: {update: {observers: {id: user.all_managed_observer_ids}}, create: {}},
+       observation_documents: {ud: {observation: {is_active: false, observers: {id: user.all_managed_observer_ids}}}, create: {}},
        category: {read: {}},
        subcategory: {read: {}},
        government: {cru: {}},
@@ -59,7 +59,7 @@ class UserPermission < ApplicationRecord
        operator: {cru: {}},
        law: {read: {}},
        severity: {read: {}},
-       observer: {read: {}, update: {id: user.observer_id}},
+       observer: {read: {}, update: {id: user.all_managed_observer_ids}},
        fmu: {read: {}},
        operator_document: {read: {}},
        required_operator_document_group: {read: {}},
@@ -67,9 +67,9 @@ class UserPermission < ApplicationRecord
     when "ngo_manager"
       {
         user: {manage: {id: user.id}},
-        observation: {manage: {observers: {id: user.observer_id}}, create: {}},
-        observation_report: {update: {observers: {id: user.observer_id}}, create: {}},
-        observation_documents: {ud: {observation: {is_active: false, observers: {id: user.observer_id}}}, create: {}},
+        observation: {manage: {observers: {id: user.all_managed_observer_ids}}, create: {}},
+        observation_report: {update: {observers: {id: user.all_managed_observer_ids}}, create: {}},
+        observation_documents: {ud: {observation: {is_active: false, observers: {id: user.all_managed_observer_ids}}}, create: {}},
         category: {cru: {}},
         subcategory: {cru: {}},
         government: {cru: {}},
@@ -77,7 +77,7 @@ class UserPermission < ApplicationRecord
         operator: {cru: {}},
         law: {cru: {}},
         severity: {cru: {}},
-        observer: {read: {}, update: {id: user.observer_id}},
+        observer: {read: {}, update: {id: user.all_managed_observer_ids}},
         fmu: {read: {}, update: {}},
         operator_document: {manage: {}},
         required_operator_document_group: {cru: {}},

--- a/app/resources/v1/observation_report_resource.rb
+++ b/app/resources/v1/observation_report_resource.rb
@@ -16,14 +16,8 @@ module V1
       records.where(id: ObservationReportObserver.where(observer_id: value[0].to_i).select(:observation_report_id))
     }
 
-    # TODO: Reactivate rubocop and fix this
-    # rubocop:disable Lint/RescueException
     def add_observers
-      @model.observer_ids = @model.observations.map(&:observers).map(&:ids).flatten if @model.observations.any?
-      @model.save
-    rescue => e
-      Rails.logger.warn "ObservationReport created without observers: #{e.inspect}"
+      @model.update_observers if @model.observations.any?
     end
-    # rubocop:enable Lint/RescueException
   end
 end

--- a/app/resources/v1/observation_resource.rb
+++ b/app/resources/v1/observation_resource.rb
@@ -30,7 +30,7 @@ module V1
     has_one :fmu
     has_one :observation_report
 
-    after_create :add_own_observer
+    before_create :set_user
     before_save :set_modified
     before_save :validate_status
 
@@ -111,23 +111,9 @@ module V1
       super - [:hidden, :publication_date]
     end
 
-    # This is called in an after save cause in the before save, there are still no relationships present
-    # meaning that if there are more users, they'll override the current one
-
-    # TODO: Reactivate rubocop and fix the problem
-    # rubocop:disable Lint/RescueException
-    def add_own_observer
-      user = context[:current_user]
-      # debugger
-      # @model.observers << Observer.find(user.observer_id) if user.observer_id.present?
-      @model.user_id = user.id
-      @model.save
-      # This is added because of the order of the callbacks in JAR
-      @model.update_reports_observers
-    rescue => e
-      Rails.logger.warn "Observation created without user: #{e.inspect}"
+    def set_user
+      @model.user_id = context[:current_user].id
     end
-    # rubocop:enable Lint/RescueException
 
     # Saves the last user who modified the observation
     def set_modified

--- a/app/resources/v1/observation_resource.rb
+++ b/app/resources/v1/observation_resource.rb
@@ -37,7 +37,7 @@ module V1
     filters :id, :observation_type, :fmu_id, :country_id,
       :publication_date, :observer_id, :subcategory_id, :years,
       :observation_report, :law, :operator, :subcategory,
-      :is_active, :validation_status, :is_physical_place, :new_observer_id
+      :is_active, :validation_status, :is_physical_place
 
     filter :hidden, default: "false", apply: ->(records, value, options) {
       return records if value.include?("all")

--- a/app/resources/v1/user_resource.rb
+++ b/app/resources/v1/user_resource.rb
@@ -10,6 +10,7 @@ module V1
     has_one :country
     has_one :user_permission, foreign_key_on: :related
     has_many :comments
+    has_many :managed_observers, class_name: "Observer"
     has_one :observer
     has_one :operator
 

--- a/app/views/admin/observations/_attributes_table.html.arb
+++ b/app/views/admin/observations/_attributes_table.html.arb
@@ -29,6 +29,13 @@ panel I18n.t("active_admin.observations_page.details") do
         safe_join(list, " ")
       end
     end
+    row :observers do |o|
+      list = o.observers.map do |observer|
+        link_to(observer.name, admin_monitor_path(observer.id))
+      end
+
+      safe_join(list, " ")
+    end
     row I18n.t("activerecord.attributes.observation.relevant_operators") do |o|
       list = o.relevant_operators.each_with_object([]) do |operator, links|
         links << link_to(operator.name, admin_producer_path(operator.id))

--- a/app/views/admin/observations/_attributes_table.html.arb
+++ b/app/views/admin/observations/_attributes_table.html.arb
@@ -11,39 +11,12 @@ panel I18n.t("active_admin.observations_page.details") do
       o.severity&.details
     end
     row :is_physical_place
-    if observation.location_information.present?
-      row :location_information
-    end
-    if observation.fmu.present?
-      row :fmu
-    end
-    if observation.operator.present?
-      row :operator
-    end
-    if observation.governments.present?
-      row I18n.t("governments.governments") do |o|
-        list = o.governments.each_with_object([]) do |government, links|
-          links << link_to(government.government_entity, admin_government_path(government.id))
-        end
-
-        safe_join(list, " ")
-      end
-    end
-    row :observers do |o|
-      list = o.observers.map do |observer|
-        link_to(observer.name, admin_monitor_path(observer.id))
-      end
-
-      safe_join(list, " ")
-    end
-    row I18n.t("activerecord.attributes.observation.relevant_operators") do |o|
-      list = o.relevant_operators.each_with_object([]) do |operator, links|
-        links << link_to(operator.name, admin_producer_path(operator.id))
-      end
-
-      safe_join(list, " ")
-    end
-
+    row :location_information if observation.location_information.present?
+    row :fmu if observation.fmu.present?
+    row :operator if observation.operator.present?
+    row :governments if observation.governments.present?
+    row :observers
+    row :relevant_operators
     row :publication_date
     row :pv
     row :location_accuracy

--- a/config/initializers/enum_attributes_validation.rb
+++ b/config/initializers/enum_attributes_validation.rb
@@ -2,6 +2,8 @@
 
 # copy paste from https://github.com/CristiRazvi/enum_attributes_validation/blob/master/lib/enum_attributes_validation.rb
 # just removed default message, could do a fork but the gem is really small so easy to include
+
+# TODO: we can remove this after upgrading to Rails 7.1, here are details https://github.com/rails/rails/pull/49100
 module EnumAttributesValidation
   extend ActiveSupport::Concern
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1437,6 +1437,7 @@ en:
         last_sign_in_at: Last sign in at  #g
         last_sign_in_ip: Last sign in ip  #g
         locale: Locale  #g
+        managed_observers: Managed observers  #g
         name: Name  #g
         observation_documents: Observation documents  #g
         observation_reports: Observation reports  #g

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1350,6 +1350,7 @@ fr:
         last_sign_in_at: Dernière connexion à  #g
         last_sign_in_ip: IP de la dernière connexion  #g
         locale: Lieu  #g
+        managed_observers: Observateurs gérés  #g
         name: Nom  #g
         observation_documents: Documents d'observation  #g
         observation_reports: Rapports d'observation  #g

--- a/db/migrate/20231011104142_create_observer_managers.rb
+++ b/db/migrate/20231011104142_create_observer_managers.rb
@@ -1,0 +1,12 @@
+class CreateObserverManagers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :observer_managers do |t|
+      t.belongs_to :observer, foreign_key: {on_delete: :cascade}, null: false
+      t.belongs_to :user, foreign_key: {on_delete: :cascade}, null: false
+
+      t.index [:user_id, :observer_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_17_162810) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_11_104142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
   enable_extension "address_standardizer_data_us"
@@ -577,6 +577,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_17_162810) do
     t.index ["validation_status"], name: "index_observations_on_validation_status"
   end
 
+  create_table "observer_managers", force: :cascade do |t|
+    t.bigint "observer_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["observer_id"], name: "index_observer_managers_on_observer_id"
+    t.index ["user_id", "observer_id"], name: "index_observer_managers_on_user_id_and_observer_id", unique: true
+    t.index ["user_id"], name: "index_observer_managers_on_user_id"
+  end
+
   create_table "observer_observations", id: :serial, force: :cascade do |t|
     t.integer "observer_id"
     t.integer "observation_id"
@@ -1140,6 +1150,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_17_162810) do
   add_foreign_key "observations", "operators"
   add_foreign_key "observations", "users"
   add_foreign_key "observations", "users", column: "modified_user_id"
+  add_foreign_key "observer_managers", "observers", on_delete: :cascade
+  add_foreign_key "observer_managers", "users", on_delete: :cascade
   add_foreign_key "observers", "users", column: "responsible_admin_id", on_delete: :nullify
   add_foreign_key "observers", "users", column: "responsible_user_id", on_delete: :nullify
   add_foreign_key "operator_document_histories", "operator_documents", on_delete: :nullify

--- a/lib/tasks/permissions_task.rake
+++ b/lib/tasks/permissions_task.rake
@@ -1,7 +1,7 @@
 namespace :permissions do
   desc "Updates the permissions for all users"
   task update: :environment do
-    UserPermission.find_each { |x|
+    UserPermission.where.not(user_role: :bo_manager).find_each { |x|
       x.change_permissions
       x.save!
     }

--- a/spec/factories/observations.rb
+++ b/spec/factories/observations.rb
@@ -45,6 +45,7 @@ FactoryBot.define do
     species { build_list(:species, 1) }
     user { build(:admin) }
     operator { build(:operator, name: "Operator #{Faker::Lorem.sentence}") }
+    observers { build_list(:observer, 1) }
     observation_type { "operator" }
     is_active { true }
     evidence_type { "Photos" }
@@ -52,6 +53,10 @@ FactoryBot.define do
     location_accuracy { "Estimated location" }
     lng { 12.2222 }
     lat { 12.3333 }
+
+    after(:build) do |observation|
+      observation.observers.each { |observer| observer.translation.name = observer.name }
+    end
   end
 
   factory :gov_observation, class: "Observation" do
@@ -59,6 +64,7 @@ FactoryBot.define do
     country
     governments { build_list(:government, 2) }
     species { build_list(:species, 1, name: "Species #{Faker::Lorem.sentence}") }
+    observers { build_list(:observer, 1) }
     user { build(:admin) }
     observation_type { "government" }
     validation_status { "Published (no comments)" }
@@ -66,6 +72,10 @@ FactoryBot.define do
     publication_date { DateTime.now.yesterday.to_date }
     lng { 12.2222 }
     lat { 12.3333 }
+
+    after(:build) do |observation|
+      observation.observers.each { |observer| observer.translation.name = observer.name }
+    end
   end
 
   factory :observation, class: "Observation" do

--- a/spec/factories/operators.rb
+++ b/spec/factories/operators.rb
@@ -21,6 +21,7 @@
 #  country_operators :integer
 #  name              :string
 #  details           :string
+#  slug              :string
 #
 
 FactoryBot.define do

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: pages
+#
+#  id                     :bigint           not null, primary key
+#  slug                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  available_in_languages :string           is an Array
+#  title                  :string
+#  body                   :text
+#
 FactoryBot.define do
   factory :page do
     title { "Title" }

--- a/spec/importers/observations_importer_spec.rb
+++ b/spec/importers/observations_importer_spec.rb
@@ -6,11 +6,11 @@ describe ObservationsImporter, type: :importer do
   let(:importer_type) { "observations" }
   let(:uploaded_file) { fixture_file_upload("#{importer_type}/import_data.csv", Mime[:csv].to_s) }
   let(:importer) { FileDataImport::BaseImporter.build(importer_type, uploaded_file) }
+  let(:observer) { create(:observer) }
 
   context "CSV" do
-    # TODO: fix importer or remove it
-    xit "returns right result" do
-      importer.import
+    it "returns right result" do
+      importer.import observer_ids: [observer.id]
 
       expect(importer.results.to_json).to match_snapshot("importers/observations_importer")
     end

--- a/spec/importers/observations_importer_spec.rb
+++ b/spec/importers/observations_importer_spec.rb
@@ -8,7 +8,8 @@ describe ObservationsImporter, type: :importer do
   let(:importer) { FileDataImport::BaseImporter.build(importer_type, uploaded_file) }
 
   context "CSV" do
-    it "returns right result" do
+    # TODO: fix importer or remove it
+    xit "returns right result" do
       importer.import
 
       expect(importer.results.to_json).to match_snapshot("importers/observations_importer")

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -276,6 +276,20 @@ RSpec.describe Observation, type: :model do
       end
     end
 
+    describe "#update_reports_observers" do
+      let(:observation_report) { create(:observation_report) }
+      let(:observer1) { create(:observer) }
+      let(:observer2) { create(:observer) }
+
+      context "when creating observation with the report" do
+        it "assigns reports to observers associated with observation" do
+          create(:observation, observers: [observer1, observer2], observation_report: observation_report)
+
+          expect(observation_report.observer_ids.sort).to eql([observer1.id, observer2.id].sort)
+        end
+      end
+    end
+
     describe "#set_publication_date" do
       context "when publishing an observation" do
         it "set publication_date with the current date" do

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -21,6 +21,7 @@
 #  country_operators :integer
 #  name              :string
 #  details           :string
+#  slug              :string
 #
 
 require "rails_helper"

--- a/spec/models/user_permission_spec.rb
+++ b/spec/models/user_permission_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe UserPermission, type: :model do
 
   let(:ngo_permissions) {
     {user: {manage: {id: @user.id}},
-     observation: {manage: {observers: {id: @user.observer_id}}, create: {}},
-     observation_report: {update: {observers: {id: @user.observer_id}}, create: {}},
-     observation_documents: {ud: {observation: {is_active: false, observers: {id: @user.observer_id}}}, create: {}},
+     observation: {manage: {observers: {id: @user.all_managed_observer_ids}}, create: {}},
+     observation_report: {update: {observers: {id: @user.all_managed_observer_ids}}, create: {}},
+     observation_documents: {ud: {observation: {is_active: false, observers: {id: @user.all_managed_observer_ids}}}, create: {}},
      category: {read: {}},
      subcategory: {read: {}},
      government: {cru: {}},
@@ -42,7 +42,7 @@ RSpec.describe UserPermission, type: :model do
      operator: {cru: {}},
      law: {read: {}},
      severity: {read: {}},
-     observer: {read: {}, update: {id: @user.observer_id}},
+     observer: {read: {}, update: {id: @user.all_managed_observer_ids}},
      fmu: {read: {}},
      operator_document: {read: {}},
      required_operator_document_group: {read: {}},
@@ -52,9 +52,9 @@ RSpec.describe UserPermission, type: :model do
   let(:ngo_manager_permissions) {
     {
       user: {manage: {id: @user.id}},
-      observation: {manage: {observers: {id: @user.observer_id}}, create: {}},
-      observation_report: {update: {observers: {id: @user.observer_id}}, create: {}},
-      observation_documents: {ud: {observation: {is_active: false, observers: {id: @user.observer_id}}}, create: {}},
+      observation: {manage: {observers: {id: @user.all_managed_observer_ids}}, create: {}},
+      observation_report: {update: {observers: {id: @user.all_managed_observer_ids}}, create: {}},
+      observation_documents: {ud: {observation: {is_active: false, observers: {id: @user.all_managed_observer_ids}}}, create: {}},
       category: {cru: {}},
       subcategory: {cru: {}},
       government: {cru: {}},
@@ -62,7 +62,7 @@ RSpec.describe UserPermission, type: :model do
       operator: {cru: {}},
       law: {cru: {}},
       severity: {cru: {}},
-      observer: {read: {}, update: {id: @user.observer_id}},
+      observer: {read: {}, update: {id: @user.all_managed_observer_ids}},
       fmu: {read: {}, update: {}},
       operator_document: {manage: {}},
       required_operator_document_group: {cru: {}},

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -143,14 +143,27 @@ module IntegrationHelper
 
       if relationships.present?
         params[:data][:relationships] = relationships.map do |model, value|
-          {
-            model => {
-              data: {
-                type: model.to_s.pluralize,
-                id: value.to_s
+          if value.is_a? Array
+            {
+              model => {
+                data: value.map do |v|
+                  {
+                    type: model.to_s.pluralize,
+                    id: v.to_s
+                  }
+                end
               }
             }
-          }
+          else
+            {
+              model => {
+                data: {
+                  type: model.to_s.pluralize,
+                  id: value.to_s
+                }
+              }
+            }
+          end
         end.reduce(&:merge)
       end
     end


### PR DESCRIPTION
Backoffice admins and ngo and ngo_managers can now manage more observers (still belongs to one, talking about ngo and ngo_managers)

![image](https://github.com/wri/fti_api/assets/1286444/ad241718-b54a-4e86-b632-16dc66f24bbd)
