### PR TITLE
Fix version history sidebar

### DIFF
--- a/app/controllers/concerns/versionable.rb
+++ b/app/controllers/concerns/versionable.rb
@@ -3,22 +3,22 @@
 module Versionable
   def self.extended(base)
     base.instance_eval do
-      sidebar :versionate, partial: "layouts/version", only: :show
+      sidebar :versionate, partial: "version_sidebar", only: :show
 
       controller do
         def show
           model = resource.class.base_class
-          variable = current = model.includes(versions: :item).find(params[:id])
-          @versions = variable.versions.where.not(event: "create")
-          @create_version = variable.versions.where(event: "create").first
+          resource = current = model.includes(versions: :item).find(params[:id])
+          @versions = resource.versions.where.not(event: "create")
+          @create_version = resource.versions.where(event: "create").first
           begin
-            variable = @versions[params[:version].to_i].reify if params[:version]
+            resource = @versions[params[:version].to_i].reify if params[:version]
           rescue => e
             Sentry.capture_exception e
           end
           # not sure why sometimes id is nil after reify
-          variable.id = current.id if variable.id.nil?
-          instance_variable_set("@#{resource_instance_name}", variable)
+          resource.id = current.id if resource.id.nil?
+          instance_variable_set("@#{resource_instance_name}", resource)
           show! # it seems to need this
         end
       end

--- a/app/views/active_admin/resource/_version_sidebar.html.erb
+++ b/app/views/active_admin/resource/_version_sidebar.html.erb
@@ -8,14 +8,13 @@
   <b><%= I18n.t('active_admin.versionate.user') %></b><%= User.find(last_version.whodunnit).email rescue '' %>
   <br>
   <% if @versions.length.to_i > 0 %>
-    <% if params[:version].to_i > 0 || !params[:version] %>
-      <%= link_to I18n.t('active_admin.versionate.previous_version'), {:version => (params[:version] || @versions.length).to_i - 1}%>
-      <br>
-    <% end %>
+
     <% if params[:version] %>
       <% version = @versions[params[:version].to_i] %>
 
       <% if version %>
+        <%= link_to I18n.t('active_admin.versionate.go_to_current_version')%>
+
         <h3><%= I18n.t('active_admin.versionate.this_is_version', number: params[:version]) %></h3>
 
         <% reify_version_info = version.previous %>
@@ -27,13 +26,16 @@
           <br>
           <br>
         <% end %>
-        <b><%= I18n.t('active_admin.versionate.created_at') %></b><%= version.created_at %>
+        <b><%= I18n.t('active_admin.versionate.modified_at') %></b><%= version.created_at %>
         <br>
         <b><%= I18n.t('active_admin.versionate.user') %></b> <%= User.find(version.whodunnit).email rescue '' %>
         <br>
-
-        <%= link_to I18n.t('active_admin.versionate.go_to_current_version')%>
       <% end %>
+    <% end %>
+
+    <% if params[:version].to_i > 0 || !params[:version] %>
+      <%= link_to I18n.t('active_admin.versionate.previous_version'), {:version => (params[:version] || @versions.length).to_i - 1}%>
+      <br>
     <% end %>
   <% end %>
 <% elsif @create_version %>


### PR DESCRIPTION
There should be two dates for the previous version in the history sidebar, created at and modified at. Due to typo when making translations both dates were named as "created at". Additionally, I'm moving links to current and previous versions to be in more intuitive places.

![image](https://github.com/wri/fti_api/assets/1286444/3ca43755-14f3-40a4-b4a0-77eab5953b03)
