### PR TITLE
Assign observers from observation report

### DIFF
--- a/app/admin/observation.rb
+++ b/app/admin/observation.rb
@@ -63,7 +63,7 @@ ActiveAdmin.register Observation do
             :validation_status, :publication_date, :observation_report_id, :location_information, :evidence_type,
             :evidence_on_report, :location_accuracy, :law_id, :fmu_id, :hidden, :admin_comment,
             :monitor_comment, :actions_taken, :is_physical_place,
-            observer_ids: [], relevant_operator_ids: [], government_ids: [],
+            relevant_operator_ids: [], government_ids: [],
             observation_documents_attributes: [:id, :name, :attachment],
             translations_attributes: [:id, :locale, :details, :concern_opinion, :litigation_status, :_destroy]
           ]
@@ -547,7 +547,7 @@ ActiveAdmin.register Observation do
 
       f.input :is_physical_place, **visibility
       f.input :location_information, **visibility if f.object.observation_type == "operator"
-      f.input :observers, **visibility
+      f.input :observers, input_html: {disabled: true}
 
       f.input :relevant_operator_ids,
         label: I18n.t("activerecord.attributes.observation.relevant_operators"),

--- a/app/admin/observation_report.rb
+++ b/app/admin/observation_report.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register ObservationReport do
 
   actions :all, except: [:new]
 
-  permit_params :user_id, :title, :publication_date, :attachment
+  permit_params :user_id, :title, :publication_date, :attachment, observer_ids: []
 
   config.order_clause
   active_admin_paranoia
@@ -141,9 +141,10 @@ ActiveAdmin.register ObservationReport do
       f.input :title
       f.input :publication_date, as: :date_time_picker, picker_options: {timepicker: false, format: "Y-m-d"}
       f.input :attachment, as: :file, hint: f.object&.attachment&.file&.filename
-
-      f.actions
+      f.input :observers
     end
+
+    f.actions
   end
 
   show do

--- a/app/admin/observation_report.rb
+++ b/app/admin/observation_report.rb
@@ -151,6 +151,8 @@ ActiveAdmin.register ObservationReport do
     attributes_table do
       row :title
       row :publication_date
+      row :observers
+      row :observations
       row :user
       row :created_at
       row :updated_at

--- a/app/models/observation_report.rb
+++ b/app/models/observation_report.rb
@@ -25,7 +25,7 @@ class ObservationReport < ApplicationRecord
   # API creating report fails as it's not providing user. Thing to investigate
   belongs_to :user, inverse_of: :observation_reports, optional: true
   has_many :observation_report_observers, dependent: :destroy
-  has_many :observers, through: :observation_report_observers
+  has_many :observers, through: :observation_report_observers, after_add: :self_touch, after_remove: :self_touch
   has_many :observations, dependent: :destroy
 
   skip_callback :commit, :after, :remove_attachment!
@@ -33,9 +33,19 @@ class ObservationReport < ApplicationRecord
   after_restore :move_attachment_to_public_directory
   after_real_destroy :remove_attachment!
 
+  after_commit :sync_observation_observers
+
   scope :bigger_date, ->(date) { where("observation_reports.created_at <= ?", date + 1.day) }
 
-  def update_observers
-    self.observer_ids = observations.joins(:observers).distinct.pluck("observers.id") if observations.any?
+  private
+
+  def self_touch(_)
+    touch unless destroyed? || new_record?
+  end
+
+  def sync_observation_observers
+    observations.with_deleted.find_each do |observation|
+      observation.observers = observers
+    end
   end
 end

--- a/app/models/observation_report.rb
+++ b/app/models/observation_report.rb
@@ -28,6 +28,11 @@ class ObservationReport < ApplicationRecord
   has_many :observers, through: :observation_report_observers, after_add: :self_touch, after_remove: :self_touch
   has_many :observations, dependent: :destroy
 
+  validates :attachment, presence: true
+  validates :observers, presence: true
+  validates :title, presence: true
+  validates :publication_date, presence: true
+
   skip_callback :commit, :after, :remove_attachment!
   after_destroy :move_attachment_to_private_directory
   after_restore :move_attachment_to_public_directory

--- a/app/models/observation_report.rb
+++ b/app/models/observation_report.rb
@@ -38,7 +38,8 @@ class ObservationReport < ApplicationRecord
   after_restore :move_attachment_to_public_directory
   after_real_destroy :remove_attachment!
 
-  after_commit :sync_observation_observers
+  attr_accessor :skip_observers_sync
+  after_commit :sync_observation_observers, unless: :skip_observers_sync
 
   scope :bigger_date, ->(date) { where("observation_reports.created_at <= ?", date + 1.day) }
 

--- a/app/models/operator_document_annex.rb
+++ b/app/models/operator_document_annex.rb
@@ -24,7 +24,7 @@ class OperatorDocumentAnnex < ApplicationRecord
 
   mount_base64_uploader :attachment, OperatorDocumentAnnexUploader
 
-  belongs_to :user
+  belongs_to :user, optional: true # FIX db data to eliminate this
   has_many :annex_documents, inverse_of: :operator_document_annex
   has_one :annex_document, -> { where(documentable_type: "OperatorDocument") }, inverse_of: :operator_document_annex
   has_one :operator_document, through: :annex_document, required: false, source: :documentable, source_type: "OperatorDocument"

--- a/app/resources/v1/observation_report_resource.rb
+++ b/app/resources/v1/observation_report_resource.rb
@@ -9,15 +9,9 @@ module V1
     has_many :observers
     has_many :observations
 
-    after_create :add_observers
-
     filter :observer_id, apply: ->(records, value, _options) {
       records.where(id: ObservationReportObserver.where(observer_id: value[0].to_i).select(:observation_report_id))
     }
-
-    def add_observers
-      @model.update_observers if @model.observations.any?
-    end
 
     def fetchable_fields
       return super if observations_tool_user?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,6 +57,17 @@ OperatorDocumentAnnex.find_each { |a| a.update!(user: operator) }
 
 $stdout.puts "Syncing test data..."
 
+sample_file_base64 = "data:application/pdf;base64,#{Base64.encode64(File.read(File.join(Rails.root, "spec", "support", "files", "doc.pdf")))}"
+
+# observation report has validation on attachment, so to not fail some e2e specs make sure all reports has some attachments
+ObservationReport.find_each do |report|
+  if report.attachment.blank?
+    report.remove_attachment!
+    report.skip_observers_sync = true
+    report.save!(validate: false)
+    report.update!(attachment: sample_file_base64)
+  end
+end
 Fmu.find_each(&:update_geometry)
 Rake::Task["sync:ranking"].invoke
 Operator.find_each { |o| ScoreOperatorDocument.recalculate!(o) }

--- a/spec/acceptance/fmus_spec.rb
+++ b/spec/acceptance/fmus_spec.rb
@@ -34,7 +34,7 @@ If not, then the request is processed as a typical JSON API request.'
 
     before do
       create(:fmu_operator, fmu: fmu_with_obs, operator: operator)
-      create(:observation, operator: operator, fmu: fmu_with_obs, observers: [observer])
+      create(:observation, operator: operator, fmu: fmu_with_obs, observation_report: create(:observation_report, observers: [observer]))
     end
 
     context "200" do

--- a/spec/acceptance/operators_spec.rb
+++ b/spec/acceptance/operators_spec.rb
@@ -33,7 +33,7 @@ resource "Operators" do
     let(:operator_with_obs) { create(:operator, country: country) }
 
     before do
-      create(:observation, operator: operator_with_obs, observers: [observer])
+      create(:observation, operator: operator_with_obs, observation_report: create(:observation_report, observers: [observer]))
     end
 
     example_request "Listing operators" do

--- a/spec/factories/observation_reports.rb
+++ b/spec/factories/observation_reports.rb
@@ -17,9 +17,11 @@ FactoryBot.define do
     sequence(:title) { |n| "ObservationReportTitle#{n}" }
     publication_date { DateTime.current }
     attachment { Rack::Test::UploadedFile.new(File.join(Rails.root, "spec", "support", "files", "image.png")) }
+    observers { build_list(:observer, 1) }
 
     after(:build) do |random_observation_report|
       random_observation_report.user ||= FactoryBot.create(:user)
+      random_observation_report.observers.each { |observer| observer.translation.name = observer.name }
     end
   end
 end

--- a/spec/factories/observations.rb
+++ b/spec/factories/observations.rb
@@ -38,45 +38,6 @@
 #
 
 FactoryBot.define do
-  factory :observation_1, class: "Observation" do
-    severity
-    country
-    species { build_list(:species, 1) }
-    user { build(:admin) }
-    operator { build(:operator, name: "Operator #{Faker::Lorem.sentence}") }
-    observers { build_list(:observer, 1) }
-    observation_type { "operator" }
-    is_active { true }
-    evidence_type { "Photos" }
-    publication_date { DateTime.now.to_date }
-    location_accuracy { "Estimated location" }
-    lng { 12.2222 }
-    lat { 12.3333 }
-
-    after(:build) do |observation|
-      observation.observers.each { |observer| observer.translation.name = observer.name }
-    end
-  end
-
-  factory :gov_observation, class: "Observation" do
-    severity
-    country
-    governments { build_list(:government, 2) }
-    species { build_list(:species, 1, name: "Species #{Faker::Lorem.sentence}") }
-    observers { build_list(:observer, 1) }
-    user { build(:admin) }
-    observation_type { "government" }
-    validation_status { "Published (no comments)" }
-    is_active { true }
-    publication_date { DateTime.now.yesterday.to_date }
-    lng { 12.2222 }
-    lat { 12.3333 }
-
-    after(:build) do |observation|
-      observation.observers.each { |observer| observer.translation.name = observer.name }
-    end
-  end
-
   factory :observation, class: "Observation" do
     country
     subcategory
@@ -86,10 +47,9 @@ FactoryBot.define do
     severity { build(:severity, subcategory: subcategory) }
     operator { create(:operator, country: country) }
     observation_type { "operator" }
-    observers { build_list(:observer, 1) }
-    species { build_list(:species, 1, name: "Species #{Faker::Lorem.sentence}") }
     is_active { true }
     validation_status { "Published (no comments)" }
+    is_physical_place { true }
     lng { 12.2222 }
     lat { 12.3333 }
 
@@ -107,6 +67,22 @@ FactoryBot.define do
 
     after(:create) do |doc, evaluator|
       doc.update(validation_status: evaluator.force_status) if evaluator.force_status
+    end
+  end
+
+  factory :gov_observation, class: "Observation" do
+    severity
+    country
+    governments { build_list(:government, 2) }
+    observers { build_list(:observer, 1) }
+    user { build(:admin) }
+    observation_type { "government" }
+    validation_status { "Published (no comments)" }
+    is_active { true }
+    publication_date { DateTime.now.yesterday.to_date }
+
+    after(:build) do |observation|
+      observation.observers.each { |observer| observer.translation.name = observer.name }
     end
   end
 

--- a/spec/integration/v1/observation_report_spec.rb
+++ b/spec/integration/v1/observation_report_spec.rb
@@ -3,13 +3,25 @@ require "rails_helper"
 module V1
   describe "Observation Reports", type: :request do
     let(:user) { create(:user) }
+    let(:document_data) {
+      "data:application/pdf;base64,#{Base64.encode64(File.read(File.join(Rails.root, "spec", "support", "files", "doc.pdf")))}"
+    }
+    let(:observer) { create(:observer) }
 
     it_behaves_like "jsonapi-resources", ObservationReport, {
       show: {},
       create: {
         success_roles: %i[admin],
         failure_roles: %i[user],
-        valid_params: -> { {title: "Report one", relationships: {user: user.id}} }
+        valid_params: -> {
+          {
+            title: "Report one",
+            "publication-date": Time.zone.today.to_s,
+            attachment: document_data,
+            relationships: {user: user.id, observers: [observer.id]}
+          }
+        },
+        excluded_params: %i[attachment publication-date] # workaround as comparing publication-date does not work
       },
       edit: {
         success_roles: %i[admin],

--- a/spec/integration/v1/observations_spec.rb
+++ b/spec/integration/v1/observations_spec.rb
@@ -19,15 +19,16 @@ module V1
     let(:ngo_headers) { authorize_headers(ngo.id) }
     let!(:country) { create(:country) }
 
-    let(:observation) { create(:observation_1) }
+    let(:observation) { create(:observation) }
 
     context "Show observations" do
       before do
         poland = create(:country, name: "Poland", iso: "POL")
         spain = create(:country, name: "Spain", iso: "ESP")
         create_list(:observation, 4, country: poland)
-        create(:observation, observers: [ngo_observer], user_id: ngo.id, country: spain)
-        create(:observation, observers: [ngo_observer], user_id: ngo.id, country: spain, fmu: create(:fmu))
+        report = create(:observation_report, observers: [ngo_observer])
+        create(:observation, observation_report: report, user_id: ngo.id, country: spain)
+        create(:observation, observation_report: report, user_id: ngo.id, country: spain, fmu: create(:fmu))
         create(:gov_observation, user_id: admin.id, country: poland)
       end
 
@@ -117,7 +118,7 @@ module V1
     end
 
     context "Edit observations" do
-      let(:observation) { create(:observation_1) }
+      let(:observation) { create(:created_observation) }
 
       describe "For admin user" do
         it "Returns error object when the observation cannot be updated by admin" do
@@ -162,7 +163,7 @@ module V1
       end
 
       describe "For not admin user" do
-        let(:observation_by_user) { create(:observation_1, validation_status: "Published (no comments)", user_id: ngo.id) }
+        let(:observation_by_user) { create(:observation, validation_status: "Published (no comments)", user_id: ngo.id) }
 
         it "Do not allows to update observation by not admin user" do
           patch("/observations/#{observation.id}?app=observations-tool",

--- a/spec/integration/v1/operators_spec.rb
+++ b/spec/integration/v1/operators_spec.rb
@@ -64,7 +64,7 @@ module V1
 
         before do
           create_list(:operator, 3, country: country) # those should not be returned
-          create(:observation, operator: operator, observers: [observer])
+          create(:observation, operator: operator, observation_report: create(:observation_report, observers: [observer]))
         end
 
         it "returns only operators linked with observer observations" do

--- a/spec/models/observation_report_spec.rb
+++ b/spec/models/observation_report_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe ObservationReport, type: :model do
     expect(subject).to be_valid
   end
 
+  describe "Validations" do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:observers) }
+    it { is_expected.to validate_presence_of(:publication_date) }
+
+    it "validates presence of attachment" do
+      subject.remove_attachment!
+      expect(subject).not_to be_valid
+      expect(subject.errors.messages[:attachment]).to include("can't be blank")
+    end
+  end
+
   describe "hooks" do
     describe "sync_observation_observers" do
       let!(:observer) { create(:observer) }

--- a/spec/models/observation_report_spec.rb
+++ b/spec/models/observation_report_spec.rb
@@ -21,6 +21,38 @@ RSpec.describe ObservationReport, type: :model do
     expect(subject).to be_valid
   end
 
+  describe "hooks" do
+    describe "sync_observation_observers" do
+      let!(:observer) { create(:observer) }
+
+      context "when adding observer to report" do
+        let!(:report) { create(:observation_report) }
+        let!(:observation) { create(:observation, observation_report: report) }
+
+        before do
+          report.observers << observer
+        end
+
+        it "adds observer to observation" do
+          expect(observation.reload.observers).to include(observer)
+        end
+      end
+
+      context "when removing observer from report" do
+        let!(:report) { create(:observation_report, observers: [observer]) }
+        let!(:observation) { create(:observation, observers: [observer], observation_report: report) }
+
+        before do
+          report.observers.delete(observer)
+        end
+
+        it "removes observer from observation" do
+          expect(observation.reload.observers).not_to include(observer)
+        end
+      end
+    end
+  end
+
   describe "soft delete" do
     let!(:report) { create(:observation_report) }
 


### PR DESCRIPTION
Observation report should be the main source of observers for the observation. 

Main changes: 
- Changing observers for observation report should update all report's observations relations. 
- When setting a different observation report for existing observation, we need to make sure observers will be taken from new report.
- Disable changing observers for observation in admin panel
- Enable changing observers for observation report in admin panel 

We can keep the existing observation-observers relation for now, as changing this (removing that connection) could take a way more time. Changing API, and both applications to not seek observers in observation model but in observation report. 