### PR TITLE
Fix operator document invalid mailer

### DIFF
--- a/app/admin/operator_document_annex.rb
+++ b/app/admin/operator_document_annex.rb
@@ -134,7 +134,7 @@ ActiveAdmin.register OperatorDocumentAnnex do
   dependent_filters do
     {
       annex_documents_documentable_of_OperatorDocument_type_operator_name_eq: {
-        annex_documents_documentable_of_OperatorDocument_type_fmus_name_eq:
+        annex_documents_documentable_of_OperatorDocument_type_fmu_name_eq:
           Operator.joins(:fmus).pluck(:name, "fmus.name")
       }
     }

--- a/app/views/mailers/operator_document_mailer/document_invalid.html.mjml
+++ b/app/views/mailers/operator_document_mailer/document_invalid.html.mjml
@@ -11,7 +11,12 @@
   <%= t("mailers.document") %>: <%= @document.name_with_fmu %><br/>
   <%= OperatorDocument.human_attribute_name(:start_date) %>: <%= @document.start_date %><br/>
   <%= OperatorDocument.human_attribute_name(:expire_date) %>: <%= @document.expire_date %><br/>
+  <% if @document.reason.present? %>
+  <%= t("active_admin.operator_documents_page.reason_label") %>:
+  <%= @document.reason %>
+  <% else %>
   Link: <%= link_to nil, @document&.document_file&.attachment&.url %>
+  <% end %>
 </p>
 
 <p>

--- a/app/views/mailers/operator_document_mailer/document_invalid.text.erb
+++ b/app/views/mailers/operator_document_mailer/document_invalid.text.erb
@@ -6,7 +6,12 @@
 <%= t("mailers.document") %>: <%= @document.name_with_fmu %>
 <%= OperatorDocument.human_attribute_name(:start_date) %>: <%= @document.start_date %>
 <%= OperatorDocument.human_attribute_name(:expire_date) %>: <%= @document.expire_date %>
+<% if @document.reason.present? %>
+<%= t("active_admin.operator_documents_page.reason_label") %>:
+<%= @document.reason %>
+<% else %>
 Link: <%= @document&.document_file&.attachment&.url %>
+<% end %>
 
 <%= t(".paragraph2") %>
 <%= @document.admin_comment %>

--- a/spec/mailers/previews/operator_document_mailer_preview.rb
+++ b/spec/mailers/previews/operator_document_mailer_preview.rb
@@ -19,6 +19,10 @@ class OperatorDocumentMailerPreview < ActionMailer::Preview
     OperatorDocumentMailer.document_invalid invalid_document, test_user
   end
 
+  def document_put_as_not_required_invalid
+    OperatorDocumentMailer.document_invalid invalid_not_required_document, test_user
+  end
+
   def admin_document_pending
     OperatorDocumentMailer.admin_document_pending pending_document, test_user
   end
@@ -44,6 +48,13 @@ class OperatorDocumentMailerPreview < ActionMailer::Preview
 
   def invalid_document
     valid_document.tap do |d|
+      d.status = "doc_invalid"
+      d.admin_comment = "Document is invalid because of reasons."
+    end
+  end
+
+  def invalid_not_required_document
+    pending_document_with_reason.tap do |d|
       d.status = "doc_invalid"
       d.admin_comment = "Document is invalid because of reasons."
     end


### PR DESCRIPTION
That quick fix was already deployed to production as a hot-fix for failing invalid document mailer.