### PR TITLE
Feat/observation locale column

### DIFF
--- a/app/admin/observation.rb
+++ b/app/admin/observation.rb
@@ -595,6 +595,7 @@ ActiveAdmin.register Observation do
     end
 
     f.inputs I18n.t("active_admin.shared.translated_fields") do
+      f.input :locale, input_html: {disabled: true}
       if Observation::PUBLISHED_STATES.include? object.validation_status
         f.input :force_translations_from, label: I18n.t("active_admin.shared.translate_from"),
           as: :select,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -33,6 +33,7 @@
 #  admin_comment         :text
 #  monitor_comment       :text
 #  deleted_at            :datetime
+#  locale                :string
 #  details               :text
 #  concern_opinion       :text
 #  litigation_status     :string

--- a/app/resources/v1/observation_resource.rb
+++ b/app/resources/v1/observation_resource.rb
@@ -129,7 +129,7 @@ module V1
     def set_modified
       user = context[:current_user]
       @model.modified_user_id = user.id
-      @model.force_translations_from = user.locale
+      @model.force_translations_from = @model.locale || user.locale
     end
 
     # Makes sure the validation status can be an acceptable one

--- a/app/resources/v1/observation_resource.rb
+++ b/app/resources/v1/observation_resource.rb
@@ -10,7 +10,7 @@ module V1
       :litigation_status, :location_accuracy, :lat, :lng, :country_id,
       :fmu_id, :location_information, :subcategory_id, :severity_id,
       :created_at, :updated_at, :actions_taken, :validation_status, :validation_status_id,
-      :is_physical_place, :complete, :hidden, :admin_comment, :monitor_comment
+      :is_physical_place, :complete, :hidden, :admin_comment, :monitor_comment, :locale
 
     has_many :species
     has_many :observation_documents
@@ -30,6 +30,7 @@ module V1
     has_one :observation_report
 
     before_create :set_user
+    before_create :set_locale
     before_save :set_modified
     before_save :validate_status
 
@@ -118,6 +119,10 @@ module V1
 
     def set_user
       @model.user_id = context[:current_user].id
+    end
+
+    def set_locale
+      @model.locale = context[:current_user].locale if @model.locale.blank?
     end
 
     # Saves the last user who modified the observation and its locale

--- a/app/views/admin/observations/_attributes_table.html.arb
+++ b/app/views/admin/observations/_attributes_table.html.arb
@@ -3,6 +3,7 @@ panel I18n.t("active_admin.observations_page.details") do
     row :is_active
     row :hidden
     tag_row :validation_status
+    row :locale
     row :country
     row :observation_type
     row :subcategory

--- a/db/migrate/20240513122425_add_locale_to_observations.rb
+++ b/db/migrate/20240513122425_add_locale_to_observations.rb
@@ -1,0 +1,5 @@
+class AddLocaleToObservations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :observations, :locale, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -580,6 +580,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_16_103335) do
     t.text "admin_comment"
     t.text "monitor_comment"
     t.datetime "deleted_at", precision: nil
+    t.string "locale"
     t.index ["country_id"], name: "index_observations_on_country_id"
     t.index ["created_at"], name: "index_observations_on_created_at"
     t.index ["deleted_at"], name: "index_observations_on_deleted_at"

--- a/spec/factories/observations.rb
+++ b/spec/factories/observations.rb
@@ -31,6 +31,7 @@
 #  admin_comment         :text
 #  monitor_comment       :text
 #  deleted_at            :datetime
+#  locale                :string
 #  details               :text
 #  concern_opinion       :text
 #  litigation_status     :string

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -31,6 +31,7 @@
 #  admin_comment         :text
 #  monitor_comment       :text
 #  deleted_at            :datetime
+#  locale                :string
 #  details               :text
 #  concern_opinion       :text
 #  litigation_status     :string


### PR DESCRIPTION
Adding `locale` column to observation model. Use that locale as a default for auto-translations when publishing observation.