### PR TITLE
Update activeadmin addons with quick workaround

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,7 @@ gem "active_admin_paranoia", git: "https://github.com/tsubik/active_admin_parano
 gem "active_admin_sidebar", git: "https://github.com/activeadmin-plugins/active_admin_sidebar.git"
 gem "activeadmin"
 gem "activeadmin-globalize", github: "tsubik/activeadmin-globalize", branch: "custom"
-# looks like merging this https://github.com/platanus/activeadmin_addons/pull/442/files caused raising Formtastic::UnsupportedEnumCollection for multiple selects with enum values
-gem "activeadmin_addons", "~> 1.9.0"
+gem "activeadmin_addons"
 
 gem "sass-rails"
 gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,9 +115,10 @@ GEM
       kaminari (>= 1.2.1)
       railties (>= 6.1)
       ransack (>= 4.0)
-    activeadmin_addons (1.9.0)
+    activeadmin_addons (1.10.1)
       active_material
       railties
+      redcarpet
       require_all
       sassc
       sassc-rails
@@ -542,6 +543,7 @@ GEM
       i18n
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    redcarpet (3.6.0)
     redis (5.2.0)
       redis-client (>= 0.22.0)
     redis-actionpack (5.4.0)
@@ -757,7 +759,7 @@ DEPENDENCIES
   active_skin
   activeadmin
   activeadmin-globalize!
-  activeadmin_addons (~> 1.9.0)
+  activeadmin_addons
   activeadmin_quill_editor
   activerecord-import
   activerecord-postgis-adapter

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -369,6 +369,16 @@ ActiveAdmin.after_load do |app|
   app.view_factory.register header: CustomAdminHeader
 end
 
+# activeadmin_addons update in 1.10 introduced a bug where it raises Formtastic::UnsupportedEnumCollection for multiple selects with enum values
+# not sure why it should be raising not supported but it works so for me it's supported just fine
+# https://github.com/platanus/activeadmin_addons/pull/442/files#diff-811ca221eee9c4866653114961ac21bcd0398557bb402c60f149be506c385a8eR3
+class ActiveAdmin::Inputs::Filters::SelectInput
+  def initialize(*)
+    super
+  rescue Formtastic::UnsupportedEnumCollection
+  end
+end
+
 # Modifies the display of the CSVs so that it shows on to download an English and a French versions.
 module ActiveAdmin::ViewHelpers::DownloadFormatLinksHelper
   def build_download_format_links(formats = self.class.formats)


### PR DESCRIPTION
Currently used version is not compatible fully with active admin version, and this is causing some features like nested select input ajax filtering to not work.