### PR TITLE
Feature/Observation with non concession activity

### DIFF
--- a/app/admin/observation.rb
+++ b/app/admin/observation.rb
@@ -49,7 +49,7 @@ ActiveAdmin.register Observation do
 
   permit_params :name, :lng, :pv, :lat, :lon, :subcategory_id, :severity_id, :country_id, :operator_id, :user_type,
     :validation_status, :publication_date, :observation_report_id, :location_information, :evidence_type,
-    :evidence_on_report, :location_accuracy, :law_id, :fmu_id, :hidden,
+    :evidence_on_report, :location_accuracy, :law_id, :fmu_id, :hidden, :non_concession_activity,
     :actions_taken, :is_physical_place, :force_translations_from,
     relevant_operator_ids: [], government_ids: [],
     observation_document_ids: [],
@@ -423,6 +423,7 @@ ActiveAdmin.register Observation do
       f.input :observation_type, input_html: {disabled: true}
       if allow_override
         if f.object.observation_type == "operator"
+          f.input :non_concession_activity if f.object.country.nil? || f.object.non_concession_activity_enabled?
           f.input :fmu_id,
             as: :nested_select,
             level_1: {
@@ -472,6 +473,7 @@ ActiveAdmin.register Observation do
       else
         f.input :country, input_html: {disabled: true}
         f.input :operator, input_html: {disabled: true} if f.object.observation_type == "operator"
+        f.input :non_concession_activity, input_html: {disabled: true} if f.object.observation_type == "operator" && (f.object.country.nil? || f.object.non_concession_activity_enabled?)
         f.input :fmu, input_html: {disabled: true} if f.object.observation_type == "operator"
         f.input :subcategory, input_html: {disabled: true}
         f.input :severity, as: :string, input_html: {

--- a/app/assets/javascripts/observations.js
+++ b/app/assets/javascripts/observations.js
@@ -28,6 +28,27 @@ $(document).ready(function() {
 
   changeFieldVisibility();
   $('#observation_evidence_type').on('change', changeFieldVisibility);
+
+  function changeNonConcessionActivity() {
+    const countrySelect = $('#observation_country_id');
+    const operatorSelect = $('#observation_operator_id');
+    const fmuSelect = $('#observation_fmu_id');
+
+    const nonConcessionActivity = $('#observation_non_concession_activity');
+
+    if (nonConcessionActivity.is(':checked')) {
+      fmuSelect.data('parent', 'country_id');
+      fmuSelect.data('parent-id', countrySelect.val());
+    } else {
+      fmuSelect.data('parent', 'operator_id');
+      fmuSelect.data('parent-id', operatorSelect.val());
+    }
+
+    // TODO: this is workaround for active admin addon nested select to reinitialize the select2
+    // make sure when updating the active admin addon to check if this is still working
+    document.dispatchEvent(new Event('has_many_add:after'));
+  }
+  $('#observation_non_concession_activity').on('change', changeNonConcessionActivity);
 })
 
 

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -164,6 +164,7 @@ class Observation < ApplicationRecord
   validates :lng, numericality: {greater_than_or_equal_to: -180, less_than_or_equal_to: 180, allow_blank: true}
   validates :evidence_on_report, presence: true, if: -> { evidence_type == "Evidence presented in the report" }
   validate :status_changes, if: -> { user_type.present? }
+  validate :can_set_non_concession_activity, if: -> { non_concession_activity? }
 
   validates :observers, presence: true
   validates :observation_type, presence: true
@@ -301,6 +302,10 @@ class Observation < ApplicationRecord
     }
   end
 
+  def non_concession_activity_enabled?
+    country&.iso == "COD"
+  end
+
   private
 
   def nullify_evidence_on_report
@@ -380,6 +385,10 @@ class Observation < ApplicationRecord
 
     errors.add(:validation_status,
       "Invalid validation change for #{@user_type}. Can't move from '#{validation_status_was}' to '#{validation_status}'")
+  end
+
+  def can_set_non_concession_activity
+    errors.add(:non_concession_activity, :not_allowed_for_country) unless non_concession_activity_enabled?
   end
 
   def remove_documents

--- a/app/resources/v1/observation_resource.rb
+++ b/app/resources/v1/observation_resource.rb
@@ -11,7 +11,7 @@ module V1
     attributes :observation_type, :publication_date, :pv, :is_active,
       :details, :evidence_type, :evidence_on_report, :concern_opinion,
       :litigation_status, :location_accuracy, :lat, :lng, :country_id,
-      :fmu_id, :location_information, :subcategory_id, :severity_id,
+      :fmu_id, :non_concession_activity, :location_information, :subcategory_id, :severity_id,
       :created_at, :updated_at, :actions_taken, :validation_status, :validation_status_id,
       :is_physical_place, :hidden, :user_type, :monitor_comment, :locale
 

--- a/app/resources/v1/observation_resource.rb
+++ b/app/resources/v1/observation_resource.rb
@@ -73,10 +73,24 @@ module V1
       records.where(id: records.joins(:observers).where(observers: {id: value}).pluck(:id))
     }
 
+    filter :fmu_id, apply: ->(records, value, options) {
+      context = options[:context]
+      user = context[:current_user]
+
+      if context[:app] == "observations-tool" && user.present? && ["ngo", "ngo_manager", "admin"].include?(user.user_permission.user_role)
+        records.where(fmu_id: value)
+      else
+        # prevent searching up observations with non concession activity by fmu_id
+        records.where(fmu_id: value, non_concession_activity: false)
+      end
+    }
+
     def fetchable_fields
       return super if observations_tool_user?
+      non_fetchable_fields = [:monitor_comment, :created_at, :updated_at, :user, :modified_user]
+      non_fetchable_fields.concat([:fmu, :fmu_id]) if non_concession_activity
 
-      super - [:monitor_comment, :created_at, :updated_at, :user, :modified_user]
+      super - non_fetchable_fields
     end
 
     def self.sortable_fields(context)

--- a/app/views/admin/observations/_attributes_table.html.arb
+++ b/app/views/admin/observations/_attributes_table.html.arb
@@ -13,6 +13,7 @@ panel I18n.t("active_admin.observations_page.details") do
     end
     row :is_physical_place
     row :location_information if observation.location_information.present?
+    row :non_concession_activity if observation.operator? && observation.non_concession_activity_enabled?
     row :fmu if observation.fmu.present?
     row :operator if observation.operator?
     row :governments if observation.government?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -833,6 +833,7 @@ en:
         deleted_at: Deleted at  #g
         evidence_on_report: Evidence on report  #g
         evidence_type: Evidence type  #g
+        non_concession_activity: Producer conducts activities in a concession that is attributed to another producer
         fmu: :activerecord.models.fmu  #g
         governments: Governments  #g
         governments_observations: Governments observations  #g
@@ -1478,6 +1479,7 @@ en:
     errors:
       messages:
         password_complexity: "must contain at least one uppercase letter, one lowercase letter, and one digit"
+        not_allowed_for_country: "is not allowed for this country"
         qc_in_progress: "QC must be in progress"
         record_invalid: "Validation failed: %{errors}"
         restrict_dependent_destroy:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -744,6 +744,7 @@ fr:
         evidence_on_report: Preuve sur le rapport  #g
         evidence_type: Type de preuve  #g
         fmu: :activerecord.models.fmu  #g
+        non_concession_activity: Le producteur exerce des activités dans une concession attribuée à un autre producteur
         governments: Gouvernements  #g
         governments_observations: Observations des gouvernements  #g
         hidden: Invisible  #g
@@ -1397,6 +1398,7 @@ fr:
     errors:
       messages:
         password_complexity: "doit contenir au moins une lettre majuscule, une lettre minuscule et un chiffre"
+        not_allowed_for_country: "n'est pas autorisé pour ce pays"
         qc_in_progress: "Le contrôle qualité doit être en cours"
         record_invalid: 'La validation a échoué : %{errors}'
         restrict_dependent_destroy:

--- a/db/migrate/20241009073948_add_non_concession_activity_to_observations.rb
+++ b/db/migrate/20241009073948_add_non_concession_activity_to_observations.rb
@@ -1,0 +1,5 @@
+class AddNonConcessionActivityToObservations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :observations, :non_concession_activity, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_18_130301) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_09_073948) do
   create_schema "tiger"
   create_schema "tiger_data"
   create_schema "topology"
@@ -581,6 +581,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_18_130301) do
     t.text "monitor_comment"
     t.datetime "deleted_at", precision: nil
     t.string "locale"
+    t.boolean "non_concession_activity", default: false, null: false
     t.index ["country_id"], name: "index_observations_on_country_id"
     t.index ["created_at"], name: "index_observations_on_created_at"
     t.index ["deleted_at"], name: "index_observations_on_deleted_at"

--- a/spec/factories/observations.rb
+++ b/spec/factories/observations.rb
@@ -54,6 +54,7 @@ FactoryBot.define do
     is_active { true }
     validation_status { "Published (no comments)" }
     is_physical_place { true }
+    non_concession_activity { false }
     lng { 12.2222 }
     lat { 12.3333 }
 

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -112,6 +112,21 @@ RSpec.describe Observation, type: :model do
       expect(subject.errors[:location_accuracy]).to include("is not included in the list")
     end
 
+    describe "non concession activity" do
+      it "should be valid if checked for observation in COD" do
+        subject.country = build(:country, iso: "COD")
+        subject.non_concession_activity = true
+        expect(subject).to be_valid
+      end
+
+      it "should be invalid if checked for observation not in COD" do
+        subject.country = build(:country, iso: "POL")
+        subject.non_concession_activity = true
+        expect(subject).not_to be_valid
+        expect(subject.errors[:non_concession_activity]).to include("is not allowed for this country")
+      end
+    end
+
     describe "#status_changes" do
       let(:country) { create(:country) }
       let(:status) { "Created" }


### PR DESCRIPTION
Ability to note that producer is doing activities in FMU that it has no official concession (non_concession_activity). In this case, it would be possible to select non operator FMUs in the forms.

This feature is only available for DR Congo observations. 

We will not show FMU name in the portal for those observations. 

PT: https://www.pivotaltracker.com/story/show/187336758