### PR TITLE
fix CSS issues with long select2 input in observations form and menu box sizing

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -179,20 +179,15 @@ body.active_admin {
       }
     }
   }
+
+  // fixing max width issues with long select2 fields in the form
+  form .inputs ol {
+    max-width: calc(100vw - 100px);
+  }
 }
 
 .select2-container--default .select2-results__option[aria-disabled=true] {
   display: none;
-}
-
-
-// fixing layout issues https://github.com/activeadmin/activeadmin/issues/7667
-body.active_admin {
-  *,
-  *:before,
-  *:after {
-    box-sizing: unset;
-  }
 }
 
 // trying to revert this https://github.com/activeadmin/activeadmin/commit/7dd9bc89716603ba602985baf720c7d4623fbe07

--- a/app/assets/stylesheets/new_menu.scss
+++ b/app/assets/stylesheets/new_menu.scss
@@ -64,6 +64,7 @@ $skinTextColor: #1e2a33 !default;
       position: absolute;
       width: 200px;
       z-index: 1010;
+      box-sizing: content-box;
 
       a {
         background: none;


### PR DESCRIPTION
Fixing that glitch

![observation-edit-form-glitch](https://github.com/user-attachments/assets/5a70f557-dceb-4879-b761-04f90ffc8286)
