### PR TITLE
Fix/publication authorization always private

### DIFF
--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -78,12 +78,8 @@ class OperatorDocument < ApplicationRecord
   scope :by_source, ->(source_id) { where(source: source_id) }
   scope :available, -> { where(public: true) }
   scope :expirable, -> { where(status: EXPIRABLE_STATUSES) }
-  scope :signature, -> {
-                      joins(:required_operator_document).where(required_operator_documents: {contract_signature: true})
-                    }
-  scope :non_signature, -> {
-                          joins(:required_operator_document).where(required_operator_documents: {contract_signature: false})
-                        }                                                  # non signature
+  scope :signature, -> { joins(:required_operator_document).where(required_operator_documents: {contract_signature: true}) }
+  scope :non_signature, -> { joins(:required_operator_document).where(required_operator_documents: {contract_signature: false}) }
   scope :to_expire, ->(date) {
                       expirable
                         .joins(:required_operator_document)

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -141,6 +141,10 @@ class OperatorDocument < ApplicationRecord
     %w[doc_not_required doc_valid].include?(status)
   end
 
+  def publication_authorization?
+    required_operator_document.contract_signature?
+  end
+
   def name_with_fmu
     return required_operator_document.name if fmu.nil?
 

--- a/app/models/operator_document_country.rb
+++ b/app/models/operator_document_country.rb
@@ -30,7 +30,7 @@
 class OperatorDocumentCountry < OperatorDocument
   belongs_to :required_operator_document_country, foreign_key: "required_operator_document_id", inverse_of: :operator_document_countries
 
-  after_update :update_operator_approved, if: -> { required_operator_document.contract_signature? }
+  after_update :update_operator_approved, if: :publication_authorization?
 
   protected
 

--- a/app/models/operator_document_history.rb
+++ b/app/models/operator_document_history.rb
@@ -53,6 +53,10 @@ class OperatorDocumentHistory < ApplicationRecord
   enum :uploaded_by, {operator: 1, monitor: 2, admin: 3, other: 4}
   enum :source, {company: 1, forest_atlas: 2, other_source: 3}
 
+  def publication_authorization?
+    required_operator_document.contract_signature?
+  end
+
   # Returns the collection of OperatorDocumentHistory for a given operator at a point in time
   #
   # @param String operator_id The operator id

--- a/app/resources/concerns/operator_documentable.rb
+++ b/app/resources/concerns/operator_documentable.rb
@@ -64,6 +64,8 @@ module OperatorDocumentable
     end
 
     def document_public?
+      return false if @model.publication_authorization?
+
       @model.public || @model.operator.approved
     end
 
@@ -81,7 +83,7 @@ module OperatorDocumentable
 
   module ClassMethods
     def apply_includes(records, directives)
-      super.includes(:document_file)
+      super.includes(:document_file, :required_operator_document)
     end
   end
 end

--- a/app/resources/v1/operator_document_history_resource.rb
+++ b/app/resources/v1/operator_document_history_resource.rb
@@ -35,15 +35,14 @@ module V1
       @model.operator_document_created_at
     end
 
-    # TODO
     def self.records(options = {})
       context = options[:context]
-      operator = context.dig(:filters, "operator-id")
+      operator_id = context.dig(:filters, "operator-id")
       date = context.dig(:filters, "date").to_date
 
-      OperatorDocumentHistory.from_operator_at_date(operator, date).non_signature
-    rescue
-      OperatorDocumentHistory.where("true = false") unless operator && date
+      return OperatorDocumentHistory.none unless operator_id && date
+
+      OperatorDocumentHistory.from_operator_at_date(operator_id, date).non_signature
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -109,7 +109,7 @@ FactoryBot.define do
     end
 
     factory :admin do
-      sequence(:email) { |n| Faker::Internet.email }
+      sequence(:email) { |n| "admin#{n}@example.com" }
 
       first_name { "Admin" }
       last_name { "user" }

--- a/spec/integration/v1/operator_documents_spec.rb
+++ b/spec/integration/v1/operator_documents_spec.rb
@@ -9,25 +9,36 @@ module V1
       @signature_group = create(:required_operator_document_group, name: "Publication Authorization")
       country = create(:country)
       # below generates one document
-      @signature_document = create(:required_operator_document_country, required_operator_document_group: @signature_group, contract_signature: true, country: country)
-      create(:operator, country: country, fa_id: "fa_id")
+      create(:required_operator_document_country, required_operator_document_group: @signature_group, contract_signature: true, country: country)
+      @operator = create(:operator, country: country, fa_id: "fa_id", approved: false)
       document_group = create(:required_operator_document_group, name: "Some group")
       # below creates 7 country documents for operator
       create_list(:required_operator_document_country, 7, required_operator_document_group: document_group, country: country)
-      @doc_invalid = create(:operator_document_fmu)
+      @doc_invalid = create(:operator_document_fmu, operator: @operator)
       @doc_valid_private = create(
         :operator_document_fmu,
+        operator: @operator,
         start_date: 10.days.ago,
         expire_date: 10.days.from_now,
         response_date: 10.days.ago,
         public: false,
         note: "notes"
       )
-      @doc_invalid.update(status: "doc_invalid", admin_comment: "invalid")
-      @doc_valid_private.update(status: "doc_valid")
+      @doc_invalid.update!(status: "doc_invalid", admin_comment: "invalid")
+      @doc_valid_private.update!(status: "doc_valid")
+      @signature_document = @operator.reload.operator_documents.signature.first # not sure why need to reload operator
     end
 
-    describe "GET all OperatorDocuments" do
+    def sign_publication_authorization!
+      @signature_document.update!(
+        document_file: create(:document_file),
+        start_date: Time.zone.today,
+        expire_date: 1.year.from_now,
+        status: "doc_valid"
+      )
+    end
+
+    describe "GET OperatorDocuments" do
       it "is successful" do
         get("/operator-documents?locale=en", headers: admin_headers)
         expect(status).to eql(200)
@@ -53,29 +64,45 @@ module V1
           expect(returned_document[:status]).to eq("doc_invalid")
           expect(returned_document[:"admin-comment"]).to eq("invalid")
         end
+
+        it "returns publication authorization" do
+          get(operator_documents_url_with_included, headers: admin_headers)
+
+          returned_document = parsed_data.find { |d| d[:id] == @signature_document.id.to_s }[:attributes]
+
+          expect(returned_document[:status]).to eq("doc_not_provided")
+        end
       end
 
       context "when not admin" do
+        it "does not return publication authorization" do
+          get(operator_documents_url_with_included, headers: user_headers)
+
+          returned_document = parsed_data.find { |d| d[:id] == @signature_document.id.to_s }
+
+          expect(returned_document).to be_nil
+        end
+
         it "hides OperatorDocuments status" do
           get(operator_documents_url_with_included, headers: user_headers)
 
           returned_document = parsed_data.find { |d| d[:id] == @doc_invalid.id.to_s }[:attributes]
 
-          expect(parsed_data.count).to eql(10)
+          expect(parsed_data.count).to eql(9)
           expect(returned_document[:status]).to eq("doc_not_provided")
           expect(returned_document[:"admin-comment"]).to be_nil
         end
 
         context "with signed publication authorization" do
           # approved is by default true (??? weird but no need to reset it back to true)
-          before(:each) { @doc_valid_private.operator.update(approved: true) }
+          before(:each) { sign_publication_authorization! }
 
           it "returns status if document not public" do
             get(operator_documents_url_with_included, headers: user_headers)
 
             returned_document = parsed_data.find { |d| d[:id] == @doc_valid_private.id.to_s }[:attributes]
 
-            expect(parsed_data.count).to eql(10)
+            expect(parsed_data.count).to eql(9)
             expect(returned_document[:status]).to eq("doc_valid")
             expect(returned_document[:"start-date"]).to eq(@doc_valid_private.start_date.to_s)
             expect(returned_document[:"expire-date"]).to eq(@doc_valid_private.expire_date.to_s)
@@ -91,14 +118,11 @@ module V1
         end
 
         context "with not signed publication authorization" do
-          before(:each) { @doc_valid_private.operator.update(approved: false) }
-          after(:each) { @doc_valid_private.operator.update(approved: true) }
-
           it "returns not provided and hides attributes if document not public" do
             get(operator_documents_url_with_included, headers: user_headers)
 
             returned_document = parsed_data.find { |d| d[:id] == @doc_valid_private.id.to_s }[:attributes]
-            expect(parsed_data.count).to eql(10)
+            expect(parsed_data.count).to eql(9)
             expect(returned_document[:status]).to eq("doc_not_provided")
             expect(returned_document[:"start-date"]).to be_nil
             expect(returned_document[:"expire-date"]).to be_nil


### PR DESCRIPTION
Publication authorization should only be returned for admins or operators, also making it as always private document as a double check.